### PR TITLE
Terraform: Adding support for the standard AWS envars

### DIFF
--- a/tasks/terraform/README.md
+++ b/tasks/terraform/README.md
@@ -9,11 +9,11 @@ Based on the internal version by:
 In order to run the integration test that works against AWS you to setup the following
 envars so the test can pick up the right resources to execute correctly:
 
-CONCORD_TMP_DIR	 = /tmp/concord <br>
-AWS_ACCESS_KEY	 = [your_aws_access_key] <br>
-AWS_SECRET_KEY	 = [your_aws_secret_key] <br>
-TF_TEST_FILE	    = /path/to/your/main.tf <br>
-PRIVATE_KEY_PATH = /path/to/your/<aws_pem_file>
+CONCORD_TMP_DIR	       = /tmp/concord <br>
+AWS_ACCESS_KEY_ID	     = [your_aws_access_key] <br>
+AWS_SECRET_ACCESS_KEY	 = [your_aws_secret_key] <br>
+TF_TEST_FILE	         = /path/to/your/main.tf <br>
+PRIVATE_KEY_PATH       = /path/to/your/<aws_pem_file>
 
 Alternatively, you can setup the following:
 

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTest.java
@@ -65,6 +65,9 @@ import static org.mockito.Mockito.*;
 //
 // Once setup this should just allow you to run the test.
 //
+// TODO: need to test destroy, computes are left in AWS
+// TODO: split test apart to prepare for testing OCI/GCP
+//
 
 @Ignore
 public class TerraformTaskTest {
@@ -263,7 +266,13 @@ public class TerraformTaskTest {
 
         if (awsCredentials.accessKey.isEmpty() && awsCredentials.secretKey.isEmpty()) {
             awsCredentials.accessKey = System.getenv("AWS_ACCESS_KEY");
+            if (awsCredentials.accessKey == null) {
+                awsCredentials.accessKey = System.getenv("AWS_ACCESS_KEY_ID");
+            }
             awsCredentials.secretKey = System.getenv("AWS_SECRET_KEY");
+            if (awsCredentials.secretKey == null) {
+                awsCredentials.secretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+            }
         }
 
         if (awsCredentials.accessKey.isEmpty() && awsCredentials.secretKey.isEmpty()) {


### PR DESCRIPTION
The TerraformTask will now look for the standard envars that are in
the AWS docs and which most tools support:

AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY

But we will also look for the following envars not to break anyone
using them:

AWS_ACCESS_KEY
AWS_SECRET_KEY