### PR TITLE
Refactor backend management to improve general support

### DIFF
--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/BackendManager.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/BackendManager.java
@@ -1,0 +1,98 @@
+package com.walmartlabs.concord.plugins.terraform.backend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walmartlabs.concord.plugins.terraform.Constants;
+import com.walmartlabs.concord.sdk.LockService;
+import com.walmartlabs.concord.sdk.MapUtils;
+import com.walmartlabs.concord.sdk.ObjectStorage;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Named
+@Singleton
+public class BackendManager {
+
+    private final static String DEFAULT_BACKEND = "concord";
+    private final Set<String> supportedBackends;
+    private final LockService lockService;
+    private final ObjectStorage objectStorage;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public BackendManager(LockService lockService, ObjectStorage objectStorage) {
+        this.lockService = lockService;
+        this.objectStorage = objectStorage;
+        this.supportedBackends = supportedBackends();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public boolean isSupported(String backend) {
+        return supportedBackends.contains(backend);
+    }
+
+    // Supported backend types:
+    //
+    // https://www.terraform.io/docs/backends/types/index.html
+    private Set<String> supportedBackends() {
+        Set<String> supportedBackends = new HashSet<>();
+        supportedBackends.add("artifactory"); // https://www.terraform.io/docs/backends/types/artifactory.html
+        supportedBackends.add("azurerm"); // https://www.terraform.io/docs/backends/types/azurerm.html
+        supportedBackends.add("consul"); // https://www.terraform.io/docs/backends/types/consul.html
+        supportedBackends.add("etcd"); // https://www.terraform.io/docs/backends/types/etcd.html
+        supportedBackends.add("etcdv3"); // https://www.terraform.io/docs/backends/types/etcdv3.html
+        supportedBackends.add("gcs"); // https://www.terraform.io/docs/backends/types/gcs.html
+        supportedBackends.add("http"); // https://www.terraform.io/docs/backends/types/http.html
+        supportedBackends.add("manta"); // https://www.terraform.io/docs/backends/types/manta.html
+        supportedBackends.add("oss"); // https://www.terraform.io/docs/backends/types/oss.html
+        supportedBackends.add("p3"); // https://www.terraform.io/docs/backends/types/pg.html
+        supportedBackends.add("s3"); // https://www.terraform.io/docs/backends/types/s3.html
+        supportedBackends.add("swift"); https://www.terraform.io/docs/backends/types/swift.html
+        supportedBackends.add("atlas"); https://www.terraform.io/docs/backends/types/terraform-enterprise.html
+        //
+        // This requires special processing as it's not a strict set of key-value pairs, but if you're
+        // using TF Enterprise you're likely not going to be using Concord but if you're migrating from
+        // TF Enterprise to Concord you might want to use TFE's remote state engine as part
+        // of a transition.
+        //
+        // supportedBackends.add("remote"); //https://www.terraform.io/docs/backends/types/remote.html
+        //
+        return supportedBackends;
+    }
+
+    public Backend getBackend(Map<String, Object> cfg) {
+        boolean debug = MapUtils.get(cfg, Constants.DEBUG_KEY, false, Boolean.class);
+        String backendId = DEFAULT_BACKEND;
+        if (cfg.get(Constants.BACKEND_KEY) != null) {
+            if (Map.class.isAssignableFrom(cfg.get(Constants.BACKEND_KEY).getClass())) {
+                Map<String, Object> backend = MapUtils.getMap(cfg, Constants.BACKEND_KEY, null);
+                if (backend.keySet().size() > 1) {
+                    throw new IllegalArgumentException(
+                            String.format("Only a single backend configuration is supported. There are %s configured.", backend.keySet().size()));
+                }
+                backendId = backend.keySet().iterator().next();
+                if (isSupported(backendId)) {
+                    // Retrieve the backend configuration parameters
+                    return new SupportedBackend(debug, backendId, MapUtils.getMap(backend, backendId, null), objectMapper);
+                }
+            } else {
+                backendId = MapUtils.getString(cfg, Constants.BACKEND_KEY, DEFAULT_BACKEND);
+            }
+        }
+        switch (backendId) {
+            case "none": {
+                return new DummyBackend();
+            }
+            case "concord": {
+                return new ConcordBackend(debug, lockService, objectStorage, objectMapper);
+            }
+            default: {
+                throw new IllegalArgumentException("Unsupported backend type: " + backendId);
+            }
+        }
+    }
+}

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/SupportedBackend.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/SupportedBackend.java
@@ -21,23 +21,16 @@ package com.walmartlabs.concord.plugins.terraform.backend;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.walmartlabs.concord.plugins.terraform.Constants;
 import com.walmartlabs.concord.sdk.Context;
-import com.walmartlabs.concord.sdk.ContextUtils;
-import com.walmartlabs.concord.sdk.LockService;
-import com.walmartlabs.concord.sdk.ObjectStorage;
-import com.walmartlabs.concord.sdk.ProjectInfo;
-import com.walmartlabs.concord.sdk.RepositoryInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SupportedBackend implements Backend {
 
@@ -45,25 +38,14 @@ public class SupportedBackend implements Backend {
 
     private final boolean debug;
     private final String backendId;
-    private final Map<String,Object> backendParameters;
+    private final Map<String, Object> backendParameters;
     private final ObjectMapper objectMapper;
-    private final static Set<String> supportedBackends = supportedBackends();
 
-    public SupportedBackend(boolean debug, String backendId, Map<String,Object> backendParameters, ObjectMapper objectMapper) {
+    public SupportedBackend(boolean debug, String backendId, Map<String, Object> backendParameters, ObjectMapper objectMapper) {
         this.debug = debug;
         this.backendId = backendId;
         this.backendParameters = backendParameters;
         this.objectMapper = objectMapper;
-    }
-
-    public static boolean backendSupported(String backend) {
-        return supportedBackends.contains(backend);
-    }
-
-    private static Set<String> supportedBackends() {
-        Set<String> supportedBackends = new HashSet<>();
-        supportedBackends.add("s3");
-        return supportedBackends;
     }
 
     @Override

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/backend/BackendManagerTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/backend/BackendManagerTest.java
@@ -1,0 +1,125 @@
+package com.walmartlabs.concord.plugins.terraform.backend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.walmartlabs.concord.plugins.terraform.Constants;
+import com.walmartlabs.concord.plugins.terraform.TerraformTaskTest;
+import com.walmartlabs.concord.sdk.Context;
+import com.walmartlabs.concord.sdk.LockService;
+import com.walmartlabs.concord.sdk.MockContext;
+import com.walmartlabs.concord.sdk.ObjectStorage;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class BackendManagerTest {
+
+    private LockService lockService;
+    private ObjectStorage objectStorage;
+    private BackendManager backendManager;
+    private Path dstDir;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig().port(12345));
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        lockService = mock(LockService.class);
+        objectStorage = TerraformTaskTest.createObjectStorage(wireMockRule);
+        backendManager = new BackendManager(lockService, objectStorage);
+        dstDir = Files.createTempDirectory(Paths.get("/tmp/concord"), "test");
+    }
+
+    @Test
+    public void validateBackendManagerRejectsUnsupportedBackends() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Unsupported backend type: donkykong");
+        backendManager.getBackend(backendConfiguration("donkykong", new HashMap<>()));
+    }
+
+    @Test
+    public void validateBackendManagerRejectsMultipleBackendConfigurations() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Only a single backend configuration is supported. There are 2 configured.");
+        backendManager.getBackend(badBackendConfiguration());
+    }
+
+    @Test
+    public void validateS3BackendConfigurationSerialization() throws Exception {
+
+        Backend backend = backendManager.getBackend(s3BackendConfiguration());
+        backend.init(context(), dstDir);
+
+        File overrides = dstDir.resolve("concord_override.tf.json").toFile();
+        try (Reader reader = new FileReader(overrides)) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            Map<String,Object> s3 = (Map)((Map)((Map) objectMapper.readValue(reader, Map.class).get("terraform")).get("backend")).get("s3");
+            assertEquals("bucket-value", s3.get("bucket"));
+            assertEquals("key-value", s3.get("key"));
+            assertEquals("region-value", s3.get("region"));
+            assertEquals("dynamodb_table-value", s3.get("dynamodb_table"));
+            assertTrue((Boolean)s3.get("encrypt"));
+        }
+    }
+
+    private Context context() {
+        return new MockContext(new HashMap<>());
+    }
+
+    //
+    // - task: terraform
+    //     in:
+    //       backend:
+    //         s3:
+    //           bucket: "${bucket}"
+    //           key: "${key}"
+    //           region: "${region}"
+    //           encrypt: ${encrypt}
+    //           dynamodb_table: "${dynamodb_table}"
+    //
+    private Map<String,Object> s3BackendConfiguration() {
+        Map<String, Object> backendParameters = new HashMap();
+        backendParameters.put("bucket", "bucket-value");
+        backendParameters.put("key", "key-value");
+        backendParameters.put("region", "region-value");
+        backendParameters.put("encrypt", true);
+        backendParameters.put("dynamodb_table", "dynamodb_table-value");
+        return backendConfiguration("s3", backendParameters);
+    }
+
+    private Map<String,Object> backendConfiguration(String backendId, Map<String,Object> backendParameters) {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> backend = new HashMap();
+        backend.put(backendId, backendParameters);
+        cfg.put(Constants.BACKEND_KEY, backend);
+        return cfg;
+    }
+
+    private Map<String,Object> badBackendConfiguration() {
+        Map<String, Object> cfg = new HashMap<>();
+        Map<String, Object> backend = new HashMap();
+        backend.put("one", new HashMap<>());
+        backend.put("two", new HashMap<>());
+        cfg.put(Constants.BACKEND_KEY, backend);
+        return cfg;
+    }
+
+}


### PR DESCRIPTION
- Created BackendManager to encapsulate the creation and validation of Backends
- Created BackendManagerTest to make sure
  - Unsupported backends are rejected upfront
  - Only one backend can be configured
- Reworked the TerraformTaskTest to use the BackendManager