### PR TITLE
Allow the specification of the local path for the retrieve object

### DIFF
--- a/tasks/s3/src/main/java/com/walmartlabs/concord/plugins/s3/Constants.java
+++ b/tasks/s3/src/main/java/com/walmartlabs/concord/plugins/s3/Constants.java
@@ -33,6 +33,7 @@ public final class Constants {
     public static final String REGION_KEY = "region";
     public static final String RESULT_KEY = "result";
     public static final String SRC_KEY = "src";
+    public static final String DST_KEY = "dest";
 
     private Constants() {
     }


### PR DESCRIPTION
This change allows the user to specify a dst for the path in the workspace where the
retrieved object will be place, and if not specified defaults to the object key