### PR TITLE
terraform: option to use a local binary

### DIFF
--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Constants.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Constants.java
@@ -24,31 +24,33 @@ public final class Constants {
 
     public static final String ACTION_KEY = "action";
     public static final String BACKEND_KEY = "backend";
+    public static final String BACKEND_REMOTE_KEY = "remote";
     public static final String DEBUG_KEY = "debug";
     public static final String DEFAULT_ENV_KEY = "defaultEnv";
     public static final String DESTROY_KEY = "destroy";
     public static final String DIR_KEY = "dir";
     public static final String EXTRA_ENV_KEY = "extraEnv";
     public static final String EXTRA_VARS_KEY = "extraVars";
-    public static final String VARS_FILES = "varFiles";
     public static final String GIT_SSH_KEY = "gitSsh";
+    public static final String HOSTNAME_KEY = "hostname";
     public static final String IGNORE_ERRORS_KEY = "ignoreErrors";
+    public static final String IGNORE_LOCAL_BINARY_KEY = "ignoreLocalBinary";
     public static final String MODULE_KEY = "module";
     public static final String PLAN_KEY = "plan";
     public static final String RESULT_KEY = "result";
     public static final String SAVE_OUTPUT_KEY = "saveOutput";
     public static final String STATE_ID_KEY = "stateId";
-    public static final String VERBOSE_KEY = "verbose";
-    public static final String TOOL_VERSION_KEY = "toolVersion";
-    public static final String TOOL_URL_KEY = "toolUrl";
     public static final String TOKEN_KEY = "token";
-    public static final String HOSTNAME_KEY = "hostname";
-    public static final String BACKEND_REMOTE_KEY = "remote";
+    public static final String TOOL_URL_KEY = "toolUrl";
+    public static final String TOOL_VERSION_KEY = "toolVersion";
+    public static final String VARS_FILES = "varFiles";
+    public static final String VERBOSE_KEY = "verbose";
+
     public static final String TF_CLI_CONFIG_FILE_KEY = "TF_CLI_CONFIG_FILE";
 
     public static final String[] ALL_IN_PARAMS = {ACTION_KEY, BACKEND_KEY, DEBUG_KEY, DEFAULT_ENV_KEY, DESTROY_KEY,
-            DIR_KEY, EXTRA_ENV_KEY, EXTRA_VARS_KEY, VARS_FILES, GIT_SSH_KEY, IGNORE_ERRORS_KEY, MODULE_KEY, PLAN_KEY,
-            RESULT_KEY, SAVE_OUTPUT_KEY, STATE_ID_KEY, VERBOSE_KEY, TOOL_VERSION_KEY, TOOL_URL_KEY};
+            DIR_KEY, EXTRA_ENV_KEY, EXTRA_VARS_KEY, VARS_FILES, GIT_SSH_KEY, IGNORE_ERRORS_KEY, IGNORE_LOCAL_BINARY_KEY,
+            MODULE_KEY, PLAN_KEY, RESULT_KEY, SAVE_OUTPUT_KEY, STATE_ID_KEY, VERBOSE_KEY, TOOL_VERSION_KEY, TOOL_URL_KEY};
 
     private Constants() {
     }

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformBinaryResolver.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformBinaryResolver.java
@@ -1,0 +1,170 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+import com.walmartlabs.concord.common.IOUtils;
+import com.walmartlabs.concord.sdk.DependencyManager;
+import com.walmartlabs.concord.sdk.MapUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class TerraformBinaryResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(TerraformBinaryResolver.class);
+
+    private static final String DEFAULT_TERRAFORM_VERSION = "0.12.5";
+    private static final String DEFAULT_TOOL_URL_TEMPLATE = "https://releases.hashicorp.com/terraform/%s/terraform_%s_%s_amd64.zip";
+
+    private final DependencyManager dependencyManager;
+    private final Map<String, Object> cfg;
+    private final Path workDir;
+    private final boolean debug;
+
+    public TerraformBinaryResolver(DependencyManager dependencyManager, Map<String, Object> cfg, Path workDir, boolean debug) {
+        this.dependencyManager = dependencyManager;
+        this.cfg = cfg;
+        this.workDir = workDir;
+        this.debug = debug;
+    }
+
+    /**
+     * Initialize the Terraform binary.
+     * <p>
+     * The method tries the following:
+     * - downloads the binary's archive if "toolUrl" is specified
+     * - the local ${workDir}/.terraform/terraform
+     * - a "terraform" binary in $PATH (unless "ignoreLocalBinary" is set to "true")
+     * - downloads the binary using the standard URL
+     * <p>
+     * During the init we might download the version of Terraform specified by the user if defined, otherwise
+     * we will download the default version. Terraform URLs look like the following:
+     * <p>
+     * https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.5_linux_amd64.zip
+     * https://releases.hashicorp.com/terraform/0.11.2/terraform_0.11.2_linux_amd64.zip
+     * <p>
+     * So we can generalize to:
+     * <p>
+     * https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip
+     * <p>
+     * We will also allow the user to specify the full URL if they want to download the tool zip from
+     * and internal repository manager or other internally managed host.
+     *
+     * @return
+     * @throws Exception
+     */
+    public Path resolve() throws Exception {
+        Path dstDir = workDir.resolve(".terraform");
+        if (!Files.exists(dstDir)) {
+            Files.createDirectories(dstDir);
+        }
+
+        // try ${workDir}/.terraform/terraform first
+        Path binaryInWorkDir = dstDir.resolve("terraform");
+        if (Files.exists(binaryInWorkDir)) {
+            if (debug) {
+                log.info("init -> using the existing binary {}", workDir.relativize(binaryInWorkDir));
+            }
+            return binaryInWorkDir;
+        }
+
+        // try toolUrl first
+        String toolUrl = userToolUrl(cfg);
+        if (toolUrl != null) {
+            downloadAndUnpack(toolUrl, dstDir);
+        }
+
+        boolean ignoreLocalBinary = MapUtils.getBoolean(cfg, Constants.IGNORE_LOCAL_BINARY_KEY, false);
+        if (!ignoreLocalBinary) {
+            // try $PATH next
+            Path p = findBinaryInPath();
+            if (p != null) {
+                if (debug) {
+                    log.info("init -> using the existing binary {}", p);
+                }
+                return p;
+            }
+        }
+
+        // fallback: try to download the tool from a standard URL
+        toolUrl = defaultToolUrl(cfg);
+        downloadAndUnpack(toolUrl, dstDir);
+
+        if (debug) {
+            log.info("init -> extracting the binary into {}", workDir.relativize(dstDir));
+        }
+
+        return binaryInWorkDir;
+    }
+
+    private void downloadAndUnpack(String toolUrl, Path dst) throws IOException {
+        Path p = dependencyManager.resolve(URI.create(toolUrl));
+        try (InputStream in = Files.newInputStream(p)) {
+            IOUtils.unzip(in, dst);
+        }
+    }
+
+    /**
+     * Tries to run {@code which terraform} to determine whether the binary is present in $PATH or not.
+     */
+    private Path findBinaryInPath() throws InterruptedException {
+        try {
+            Process proc = new ProcessBuilder().command("which", "terraform")
+                    .start();
+
+            int code = proc.waitFor();
+            if (code != 0) {
+                if (debug) {
+                    log.info("findBinaryInPath -> non-zero exit code: {}", code);
+                }
+                return null;
+            }
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
+                String s = reader.readLine();
+                return Paths.get(s.trim());
+            }
+        } catch (IOException e) {
+            if (debug) {
+                log.warn("findBinaryInPath -> error: {}", e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    private static String userToolUrl(Map<String, Object> cfg) {
+        String toolUrl = MapUtils.getString(cfg, Constants.TOOL_URL_KEY);
+        if (toolUrl != null && !toolUrl.isEmpty()) {
+            // the user has explicitly specified a URL from where to download the tool.
+            return toolUrl;
+        }
+        return null;
+    }
+
+    private static String defaultToolUrl(Map<String, Object> cfg) {
+        String tfOs;
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("mac")) {
+            tfOs = "darwin";
+        } else if (os.contains("nux")) {
+            tfOs = "linux";
+        } else if (os.contains("win")) {
+            tfOs = "windows";
+        } else if (os.contains("sunos")) {
+            tfOs = "solaris";
+        } else {
+            throw new IllegalArgumentException("Your operating system is not supported: " + os);
+        }
+
+        // check to see if the user has specified a version of the tool to use, if not use the default version.
+        String toolVersion = MapUtils.getString(cfg, Constants.TOOL_VERSION_KEY, DEFAULT_TERRAFORM_VERSION);
+        return String.format(DEFAULT_TOOL_URL_TEMPLATE, toolVersion, toolVersion, tfOs);
+    }
+}


### PR DESCRIPTION
Refactor the current binary resolving code into `TerraformBinaryResolver`. The resolver looks for the binary using the following methods:
- looks for `${workDir}/.terraform/terraform` first;
- use `toolUrl` is specified;
- use a local binary from `$PATH` if `ignoreLocalBinary: false` (default);
- download the binary from the standard location using the default version or the version specified in `toolVersion`.

cc @jvanzyl 