### PR TITLE
terraform: update to Concord 1.63.0, fix logging, fix toolUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- terreform: fix `toolUrl` usage. Now it actually uses the downloaded
+binary;
 - terraform: fix duplicate `Starting [ACTION]...` messages;
 - terraform: Concord 1.63.0 compatibility.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- terraform: fix duplicate `Starting [ACTION]...` messages;
 - terraform: Concord 1.63.0 compatibility.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## [Unreleased]
+
+### Changed
+
+- terraform: Concord 1.63.0 compatibility.
+
+
+
 ## [1.31.0] - 2020-08-20
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <scm.connection>scm:git:https://github.com/walmartlabs/concord-plugins.git</scm.connection>
 
-        <concord.version>1.62.0</concord.version>
+        <concord.version>1.63.0</concord.version>
     </properties>
 
     <dependencyManagement>

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformBinaryResolver.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformBinaryResolver.java
@@ -96,7 +96,19 @@ public class TerraformBinaryResolver {
         // try toolUrl first
         String toolUrl = userToolUrl(cfg);
         if (toolUrl != null) {
+            if (debug) {
+                log.info("init -> using the specified toolUrl {}", toolUrl);
+            }
+
             downloadAndUnpack(toolUrl, dstDir);
+
+            // check if the remote archive actually had what we were looking for...
+            if (!Files.exists(binaryInWorkDir)) {
+                String msg = String.format("Can't find the binary in the expected place (%s) after unpacking %s", workDir.relativize(binaryInWorkDir), toolUrl);
+                throw new IllegalStateException(msg);
+            }
+
+            return binaryInWorkDir;
         }
 
         boolean ignoreLocalBinary = MapUtils.getBoolean(cfg, TaskConstants.IGNORE_LOCAL_BINARY_KEY, false);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTask.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTask.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.io.Serializable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -96,8 +95,6 @@ public class TerraformTask implements Task {
         if (debug) {
             terraform.exec(workDir, "version", "version");
         }
-
-        log.info("Starting {}...", action);
 
         try {
             TerraformActionResult result = TerraformTaskCommon.execute(terraform, action, backend, cfg, env);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
@@ -89,8 +89,6 @@ public class TerraformTaskV2 implements Task {
             terraform.exec(workDir, "version", "version");
         }
 
-        log.info("Starting {}...", action);
-
         try {
             TerraformActionResult result = TerraformTaskCommon.execute(terraform, action, backend, cfg, env);
             return convertResult(result);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/ConcordV2Backend.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/ConcordV2Backend.java
@@ -122,7 +122,7 @@ public class ConcordV2Backend implements Backend {
             return s;
         }
 
-        ProjectInfo projectInfo = ctx.projectInfo();
+        ProjectInfo projectInfo = ctx.processConfiguration().projectInfo();
         if (projectInfo == null || projectInfo.projectName() == null) {
             throw new IllegalArgumentException("Can't determine '" + TaskConstants.STATE_ID_KEY + "'. The 'concord' backend can only be used for processes running in a project.");
         }
@@ -138,7 +138,7 @@ public class ConcordV2Backend implements Backend {
     }
 
     private static String getCurrentOrgName(Context ctx) {
-        ProjectInfo projectInfo = ctx.projectInfo();
+        ProjectInfo projectInfo = ctx.processConfiguration().projectInfo();
         if (projectInfo == null || projectInfo.orgName() == null) {
             throw new IllegalArgumentException("Can't determine the current organization. The 'concord' backend can only be used for processes running in a project.");
         }


### PR DESCRIPTION
Update the Terraform plugin after a breaking change in v2 SDK.
Fix the `toolUrl` usage - it was downloading the specified archive but not actually using its binary.