### PR TITLE
terraform: fix incorrect value of hasChanges property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Change log
 
+## [Unreleased]
+
+### Changed
+
+- terraform: fix incorrect value of the `hasChanges` property of
+the result object (runtime-v2 version only).
+
+
+
 ## [1.31.1] - 2020-09-04
 
 ### Changed
 
-- terreform: fix `toolUrl` usage. Now it actually uses the downloaded
+- terraform: fix `toolUrl` usage. Now it actually uses the downloaded
 binary;
 - terraform: fix duplicate `Starting [ACTION]...` messages;
 - terraform: Concord 1.63.0 compatibility.

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
@@ -124,7 +124,7 @@ public class TerraformTaskV2 implements Task {
         }
 
         if (src.getHasChanges() != null) {
-            dst.value("hasChanges", src.getOutput());
+            dst.value("hasChanges", src.getHasChanges());
         }
 
         if (src.getPlanPath() != null) {


### PR DESCRIPTION
The v2 version of the task was incorrectly filling in the `hasChange` property in the result object.
