### PR TITLE
terraform: save .auto.tfvars.json files in $PWD

### DIFF
--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/ApplyAction.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/ApplyAction.java
@@ -80,7 +80,7 @@ public class ApplyAction extends Action {
             if (plan == null) {
                 // running without a previously created plan file
                 // save 'extraVars' into a file that can be automatically picked up by TF
-                createVarsFile(Utils.getAbsolute(workDir, dir), objectMapper, extraVars);
+                createVarsFile(workDir, objectMapper, extraVars);
             }
 
             Path dirOrPlanAbsolute = workDir.resolve(plan != null ? plan : dir);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/DestroyAction.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/DestroyAction.java
@@ -75,7 +75,7 @@ public class DestroyAction extends Action {
         try {
             init(workDir, dir, !verbose, env, terraform, backend);
 
-            createVarsFile(Utils.getAbsolute(workDir, dir), objectMapper, extraVars);
+            createVarsFile(workDir, objectMapper, extraVars);
 
             Path dirAbsolute = workDir.resolve(dir);
             List<Path> userSuppliedVarFiles = Utils.resolve(workDir, userSuppliedVarFileNames);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/PlanAction.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/PlanAction.java
@@ -82,7 +82,7 @@ public class PlanAction extends Action {
             init(workDir, dir, !verbose, env, terraform, backend);
 
             // save 'extraVars' into a file that can be automatically picked up by TF
-            createVarsFile(Utils.getAbsolute(workDir, dir), objectMapper, extraVars);
+            createVarsFile(workDir, objectMapper, extraVars);
 
             Path dirOrPlanAbsolute = workDir.resolve(plan != null ? plan : dir);
             List<Path> userSuppliedVarFiles = Utils.resolve(workDir, userSuppliedVarFileNames);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/ApplyCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/ApplyCommand.java
@@ -22,8 +22,6 @@ package com.walmartlabs.concord.plugins.terraform.commands;
 
 import com.walmartlabs.concord.plugins.terraform.Terraform;
 import com.walmartlabs.concord.plugins.terraform.Terraform.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -31,8 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 public class ApplyCommand {
-
-    private static final Logger log = LoggerFactory.getLogger(ApplyCommand.class);
 
     private final Path pwd;
     private final Path dirOrPlan;


### PR DESCRIPTION
Using `dir` and `extraVars` fails. TF is unable to find the `*.auto.tfvars.json` files generated by the plugin.

Test case:

```yaml
# concord.yml
configuration:
  dependencies:
    - "mvn://com.walmartlabs.concord.plugins:terraform-task:1.32.2"

flows:
  default:
    - task: terraform
      in:
        verbose: true
        debug: true
        backend: "none"
        action: apply
        saveOutput: true
        dir: "mydir"
        extraVars:
          region: "us-east-2"
```

```
// init.tf
terraform {
  required_version = ">= 0.12"
}

provider "aws" {
  region     = var.region
  version    = "= 2.61.0"
}

variable "region" {
  type = string
}

output "xyz" {
  value = var.region
}
```

Running:
```
curl -ik -H 'Authorization: <token>' -F concord.yml=@concord.yml -F mydir/init.tf=@init.tf http://localhost:8001/api/v1/process
```

The current version (1.32.2) fails:
```
16:27:53 [INFO ] Saving 'extraVars' as /tmp/prefork13317779678862581802/payload/mydir/.vars14720938291723192798.auto.tfvars.json...
16:27:53 [INFO ] exec -> using out file: /tmp/prefork13317779678862581802/payload/_attachments/terraform/tfd21e7ceb-7e84-4253-98b6-afbe63a5d571.plan
16:27:53 [INFO ] exec -> /home/ibodrov/bin/terraform plan -input=false -detailed-exitcode -out=/tmp/prefork13317779678862581802/payload/_attachments/terraform/tfd21e7ceb-7e84-4253-98b6-afbe63a5d571.plan /tmp/prefork13317779678862581802/payload/mydir in /tmp/prefork13317779678862581802/payload
16:27:53 [INFO ] exec -> using env: {GIT_SSH_COMMAND=/tmp/prefork13317779678862581802/payload/gitSsh3861911149083594441.sh}
terraform plan: 
terraform plan: Error: No value for required variable
terraform plan: 
terraform plan:   on mydir/init.tf line 10:
terraform plan:   10: variable "region" {
```