### PR TITLE
terraform: allow specifying the PWD

### DIFF
--- a/tasks/terraform/README.md
+++ b/tasks/terraform/README.md
@@ -6,19 +6,37 @@ Based on the internal version by:
 
 ## Testing
 
-In order to run the integration test that works against AWS you need to setup the following
-envars so the test can pick up the right resources to execute correctly:
+### TerraformTaskIT
 
-CONCORD_TMP_DIR	       = /tmp/concord <br>
-AWS_ACCESS_KEY_ID	     = [your_aws_access_key] <br>
-AWS_SECRET_ACCESS_KEY	 = [your_aws_secret_key] <br>
-TF_TEST_FILE	         = /path/to/your/main.tf <br>
-PRIVATE_KEY_PATH       = /path/to/your/<aws_pem_file>
+The test uses [testcontainers-concord](https://github.com/concord-workflow/testcontainers-concord)
+and should be self-contained.
 
-Alternatively, you can setup the following:
+Run
 
-1) Create an `~/.aws/credentials` file with a `concord-integration-tests` stanza. The access key id and secret key will
-be taken from the `concord-integration-tests` stanza:
+```
+./mvnw -pl :terraform-task clean install -DskipTests
+./mvnw -pl :terraform-task integration-test -Pit
+```
+
+### TerraformTaskTest
+
+In order to run `TerraformTaskTest` that works against AWS you need to set up
+the following envars, so the test can pick up the right resources to execute
+correctly:
+
+```
+CONCORD_TMP_DIR         = /tmp/concord
+AWS_ACCESS_KEY_ID	    = [your_aws_access_key]
+AWS_SECRET_ACCESS_KEY	= [your_aws_secret_key]
+TF_TEST_FILE	        = /path/to/your/main.tf
+PRIVATE_KEY_PATH        = /path/to/your/<aws_pem_file>
+```
+
+Alternatively, you can set up the following:
+
+1) Create an `~/.aws/credentials` file with a `concord-integration-tests`
+   stanza. The access key id and secret key will be taken from
+   the `concord-integration-tests` stanza:
 
 ```
 [default]
@@ -30,8 +48,14 @@ aws_access_key_id=xxx
 aws_secret_access_key=xxx
 ```
 
-If you do have the standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` envars set they will be used as a fallback if the `~/.aws/credentials` file doesn't exist.
+If you do have the standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+envars set they will be used as a fallback if the `~/.aws/credentials` file
+doesn't exist.
 
-2) Create a keypair in AWS called `concord-integration-tests` and place the downloaded PEM file here: `~/.aws/concord-integration-tests.pem`. This will be used as the private key for the integration test.
+2) Create a keypair in AWS called `concord-integration-tests` and place
+   the downloaded PEM file here: `~/.aws/concord-integration-tests.pem`.
+   This will be used as the private key for the integration test.
 
-The Terraform file used for the test will default the `src/test/terraform/main.tf` and the value for the `CONCORD_TMP_DIR` envar will be set for you if it is not present.
+The Terraform file used for the test will default
+the `src/test/terraform/main.tf` and the value for the `CONCORD_TMP_DIR`
+envar will be set for you if it is not present.

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TaskConstants.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TaskConstants.java
@@ -37,6 +37,7 @@ public final class TaskConstants {
     public static final String IGNORE_LOCAL_BINARY_KEY = "ignoreLocalBinary";
     public static final String MODULE_KEY = "module";
     public static final String PLAN_KEY = "plan";
+    public static final String PWD_KEY = "pwd";
     public static final String RESULT_KEY = "result";
     public static final String SAVE_OUTPUT_KEY = "saveOutput";
     public static final String STATE_ID_KEY = "stateId";
@@ -50,7 +51,8 @@ public final class TaskConstants {
 
     public static final String[] ALL_IN_PARAMS = {ACTION_KEY, BACKEND_KEY, DEBUG_KEY, DEFAULT_ENV_KEY, DESTROY_KEY,
             DIR_KEY, EXTRA_ENV_KEY, EXTRA_VARS_KEY, VARS_FILES, GIT_SSH_KEY, IGNORE_ERRORS_KEY, IGNORE_LOCAL_BINARY_KEY,
-            MODULE_KEY, PLAN_KEY, RESULT_KEY, SAVE_OUTPUT_KEY, STATE_ID_KEY, VERBOSE_KEY, TOOL_VERSION_KEY, TOOL_URL_KEY};
+            MODULE_KEY, PLAN_KEY, PWD_KEY, RESULT_KEY, SAVE_OUTPUT_KEY, STATE_ID_KEY, VERBOSE_KEY, TOOL_VERSION_KEY,
+            TOOL_URL_KEY};
 
     private TaskConstants() {
     }

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommon.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommon.java
@@ -27,6 +27,7 @@ import com.walmartlabs.concord.sdk.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,7 +38,12 @@ public final class TerraformTaskCommon {
 
     private static final Logger log = LoggerFactory.getLogger(TerraformTaskCommon.class);
 
-    public static TerraformActionResult execute(Terraform terraform, Action action, Backend backend, Map<String, Object> cfg, Map<String, String> env) throws Exception {
+    public static TerraformActionResult execute(Terraform terraform,
+                                                Action action,
+                                                Backend backend,
+                                                Path workDir,
+                                                Map<String, Object> cfg,
+                                                Map<String, String> env) throws Exception {
         log.info("Starting {}...", action);
 
         try {
@@ -45,19 +51,19 @@ public final class TerraformTaskCommon {
 
             switch (action) {
                 case PLAN: {
-                    PlanAction a = new PlanAction(cfg, env);
+                    PlanAction a = new PlanAction(workDir, cfg, env);
                     return a.exec(terraform, backend);
                 }
                 case APPLY: {
-                    ApplyAction a = new ApplyAction(cfg, env);
+                    ApplyAction a = new ApplyAction(workDir, cfg, env);
                     return a.exec(terraform, backend);
                 }
                 case DESTROY: {
-                    DestroyAction a = new DestroyAction(cfg, env);
+                    DestroyAction a = new DestroyAction(workDir, cfg, env);
                     return a.exec(terraform, backend);
                 }
                 case OUTPUT: {
-                    OutputAction a = new OutputAction(cfg, env, false);
+                    OutputAction a = new OutputAction(workDir, cfg, env, false);
                     return a.exec(terraform, backend);
                 }
                 default:

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
@@ -25,7 +25,6 @@ import com.walmartlabs.concord.plugins.terraform.actions.TerraformActionResult;
 import com.walmartlabs.concord.plugins.terraform.backend.Backend;
 import com.walmartlabs.concord.plugins.terraform.backend.BackendFactoryV2;
 import com.walmartlabs.concord.runtime.v2.sdk.*;
-import com.walmartlabs.concord.sdk.Constants;
 import com.walmartlabs.concord.sdk.MapUtils;
 
 import javax.inject.Inject;
@@ -86,7 +85,7 @@ public class TerraformTaskV2 implements Task {
         }
 
         try {
-            TerraformActionResult result = TerraformTaskCommon.execute(terraform, action, backend, cfg, env);
+            TerraformActionResult result = TerraformTaskCommon.execute(terraform, action, backend, workDir, cfg, env);
             return convertResult(result);
         } finally {
             gitSshWrapper.cleanup();
@@ -96,7 +95,8 @@ public class TerraformTaskV2 implements Task {
     private Map<String, Object> createCfg(Path workDir, Variables input, Variables defaults) {
         Map<String, Object> m = new HashMap<>(defaults != null ? defaults.toMap() : Collections.emptyMap());
 
-        m.put(Constants.Context.WORK_DIR_KEY, workDir.toAbsolutePath().toString());
+        // default value for `pwd`
+        m.put(TaskConstants.PWD_KEY, workDir.toAbsolutePath().toString());
 
         for (String k : TaskConstants.ALL_IN_PARAMS) {
             Object v = input.get(k);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/ConcordV1Backend.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/ConcordV1Backend.java
@@ -87,13 +87,20 @@ public class ConcordV1Backend implements Backend {
                 Collections.singletonMap("backend",
                         Collections.singletonMap("http", params)));
 
-        Path p = tfDir.resolve("concord_override.tf.json");
-        try (OutputStream out = Files.newOutputStream(p, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+        Path configFile = tfDir.resolve("concord_override.tf.json").toAbsolutePath();
+
+        Path parentDir = configFile.getParent();
+        if (!Files.exists(parentDir)) {
+            Path relative = ContextUtils.getWorkDir(ctx).relativize(parentDir);
+            throw new IllegalArgumentException("Can't create the backend configuration, the directory doesn't exist: " + relative);
+        }
+
+        try (OutputStream out = Files.newOutputStream(configFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
             objectMapper.writeValue(out, cfg);
         }
 
         if (debug) {
-            log.info("init -> created backend configuration file in {}", p.toAbsolutePath().toString());
+            log.info("init -> created backend configuration file in {}", configFile.toAbsolutePath().toString());
         }
     }
 

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/ConcordV2Backend.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/backend/ConcordV2Backend.java
@@ -106,13 +106,20 @@ public class ConcordV2Backend implements Backend {
                 Collections.singletonMap("backend",
                         Collections.singletonMap("http", params)));
 
-        Path p = tfDir.resolve("concord_override.tf.json");
-        try (OutputStream out = Files.newOutputStream(p, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+        Path configFile = tfDir.resolve("concord_override.tf.json").toAbsolutePath();
+
+        Path parentDir = configFile.getParent();
+        if (!Files.exists(parentDir)) {
+            Path relative = ctx.workingDirectory().relativize(parentDir);
+            throw new IllegalArgumentException("Can't create the backend configuration, the directory doesn't exist: " + relative);
+        }
+
+        try (OutputStream out = Files.newOutputStream(configFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
             objectMapper.writeValue(out, cfg);
         }
 
         if (debug) {
-            log.info("init -> created backend configuration file in {}", p.toAbsolutePath().toString());
+            log.info("init -> created backend configuration file in {}", configFile.toAbsolutePath().toString());
         }
     }
 

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/DestroyCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/DestroyCommand.java
@@ -22,8 +22,6 @@ package com.walmartlabs.concord.plugins.terraform.commands;
 
 import com.walmartlabs.concord.plugins.terraform.Terraform;
 import com.walmartlabs.concord.plugins.terraform.Terraform.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -31,8 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 public class DestroyCommand {
-
-    private static final Logger log = LoggerFactory.getLogger(DestroyCommand.class);
 
     private final Path pwd;
     private final Path dir;

--- a/tasks/terraform/src/test/resources/com/walmartlabs/concord/plugins/terraform/runtimeV1/concord.yml
+++ b/tasks/terraform/src/test/resources/com/walmartlabs/concord/plugins/terraform/runtimeV1/concord.yml
@@ -5,6 +5,20 @@ configuration:
 
 flows:
   default:
+    # regular run
     - task: terraform
       in:
         action: plan
+
+    # custom $PWD
+    - task: terraform
+      in:
+        action: plan
+        pwd: mydir
+
+    # custom $PWD + [DIR]
+    - task: terraform
+      in:
+        action: plan
+        pwd: mydir
+        dir: nested

--- a/tasks/terraform/src/test/resources/com/walmartlabs/concord/plugins/terraform/runtimeV2/concord.yml
+++ b/tasks/terraform/src/test/resources/com/walmartlabs/concord/plugins/terraform/runtimeV2/concord.yml
@@ -5,6 +5,20 @@ configuration:
 
 flows:
   default:
+    # regular run
     - task: terraform
       in:
         action: plan
+
+    # custom $PWD
+    - task: terraform
+      in:
+        action: plan
+        pwd: mydir
+
+    # custom $PWD + [DIR]
+    - task: terraform
+      in:
+        action: plan
+        pwd: mydir
+        dir: nested


### PR DESCRIPTION
Some Terraform configurations expect `terraform plan` (or `apply`) to
run in a specific directory (i.e. if the files use relative paths).
This change adds a way to override the binary's `$PWD`.

Docs: https://github.com/walmartlabs/concord-website/pull/57