### PR TITLE
git: Return HEAD SHA after performing action

### DIFF
--- a/tasks/git/src/main/java/com/walmartlabs/concord/plugins/git/model/exception/RefNotFoundException.java
+++ b/tasks/git/src/main/java/com/walmartlabs/concord/plugins/git/model/exception/RefNotFoundException.java
@@ -1,0 +1,32 @@
+package com.walmartlabs.concord.plugins.git.model.exception;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2021 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+public class RefNotFoundException extends Exception {
+
+    public RefNotFoundException(String msg) {
+        super(msg);
+    }
+
+    public RefNotFoundException() {
+        super("Ref not found in branch");
+    }
+}


### PR DESCRIPTION
Returns the latest HEAD ref of the branch an action is performed on. Example response for `commitAndPush`:

```text
{
  "changeList" : [ "new-file.txt" ],
  "headSHA" : "95938259eadf6a32b7852bd230d8a8a70c5ef6da",
  "ok" : true,
  "error" : "",
  "status" : "SUCCESS"
}
```