### PR TITLE
terraform: class cast exception fix

### DIFF
--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommon.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommon.java
@@ -84,7 +84,10 @@ public final class TerraformTaskCommon {
         m.putAll(backend.prepareEnv(cfg));
 
         // user env
-        Map<String, String> extraEnv = MapUtils.getMap(cfg, TaskConstants.EXTRA_ENV_KEY, Collections.emptyMap());
+        Map<String, String> extraEnv = MapUtils.getMap(cfg, TaskConstants.EXTRA_ENV_KEY, Collections.emptyMap())
+                .entrySet().stream()
+                .filter(e -> e.getValue() != null)
+                .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
         m.putAll(extraEnv);
 
         return m;


### PR DESCRIPTION
example from docs:
```
- task: terraform
  in:
    action: destroy
    extraEnv: 
      CONFIRM_DESTROY: 1
```
finished with exception:
```
18:04:16 [ERROR] main -> unhandled exception
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
	at java.lang.ProcessEnvironment$StringEnvironment.put(ProcessEnvironment.java:221)
	at java.util.AbstractMap.putAll(AbstractMap.java:281)
	at com.walmartlabs.concord.plugins.terraform.Terraform.exec(Terraform.java:80)
	at com.walmartlabs.concord.plugins.terraform.commands.InitCommand.exec(InitCommand.java:59)
	at com.walmartlabs.concord.plugins.terraform.actions.Action.init(Action.java:137)
	at com.walmartlabs.concord.plugins.terraform.actions.DestroyAction.exec(DestroyAction.java:50)
	at com.walmartlabs.concord.plugins.terraform.TerraformTaskCommon.execute(TerraformTaskCommon.java:63)
	at com.walmartlabs.concord.plugins.terraform.TerraformTask.execute(TerraformTask.java:92)
```