### PR TITLE
taurus: update jmeter version to 5.5

### DIFF
--- a/tasks/taurus/pom.xml
+++ b/tasks/taurus/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <cmdRunnerVersion>2.2</cmdRunnerVersion>
         <jmeterRepo>https://www.apache.org/dist</jmeterRepo>
-        <jmeterVersion>5.2.1</jmeterVersion>
+        <jmeterVersion>5.5</jmeterVersion>
         <pluginsCasutgVersion>2.9</pluginsCasutgVersion>
         <pluginsMgrVersion>1.3</pluginsMgrVersion>
         <pluginsPrmctlVersion>0.4</pluginsPrmctlVersion>


### PR DESCRIPTION
This should be replaced with `DependencyManager` usage, but until then the build is broken because `5.2.1` is no longer published and this will fix it.