### PR TITLE
terraform: support for executing in a container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <scm.connection>scm:git:https://github.com/walmartlabs/concord-plugins.git</scm.connection>
 
-        <concord.version>1.93.0</concord.version>
+        <concord.version>1.95.0</concord.version>
         <junit.version>4.13.1</junit.version>
         <wiremock.version>2.27.2</wiremock.version>
     </properties>

--- a/tasks/terraform/README.md
+++ b/tasks/terraform/README.md
@@ -28,10 +28,11 @@ correctly:
 CONCORD_TMP_DIR         = /tmp/concord
 AWS_ACCESS_KEY_ID       = [your_aws_access_key]
 AWS_SECRET_ACCESS_KEY   = [your_aws_secret_key]
-TF_TEST_FILE            = /path/to/your/main.tf
-PRIVATE_KEY_PATH        = /path/to/your/<aws_pem_file>
-TF_TEST_DOCKER_IMAGE    = dockerImage/withDeps:latest
-TF_TEST_HOSTNAME        = my-laptop.local 
+TF_TEST_FILE            = /path/to/your/main.tf         # optional
+PRIVATE_KEY_PATH        = /path/to/your/<aws_pem_file>  # optional
+TF_TEST_DOCKER_IMAGE    = dockerImage/withDeps:latest   # optional
+TF_TEST_HOSTNAME        = my-laptop.local               # optional
+TF_TOOL_URL             = https://...                   # optional
 ```
 
 __NOTE: Runtime-v2 test(s) make API call to the state backend both inside the

--- a/tasks/terraform/README.md
+++ b/tasks/terraform/README.md
@@ -20,17 +20,25 @@ Run
 
 ### TerraformTaskTest
 
-In order to run `TerraformTaskTest` that works against AWS you need to set up
+In order to run `TerraformTaskTestV1` that works against AWS you need to set up
 the following envars, so the test can pick up the right resources to execute
 correctly:
 
 ```
 CONCORD_TMP_DIR         = /tmp/concord
-AWS_ACCESS_KEY_ID	    = [your_aws_access_key]
-AWS_SECRET_ACCESS_KEY	= [your_aws_secret_key]
-TF_TEST_FILE	        = /path/to/your/main.tf
+AWS_ACCESS_KEY_ID       = [your_aws_access_key]
+AWS_SECRET_ACCESS_KEY   = [your_aws_secret_key]
+TF_TEST_FILE            = /path/to/your/main.tf
 PRIVATE_KEY_PATH        = /path/to/your/<aws_pem_file>
+TF_TEST_DOCKER_IMAGE    = dockerImage/withDeps:latest
+TF_TEST_HOSTNAME        = my-laptop.local 
 ```
+
+__NOTE: Runtime-v2 test(s) make API call to the state backend both inside the
+docker container and outside. `localhost` doesn't work for that on Docker for Mac
+so it's best to provide a specific hostname. Just the hostname may work, but it may
+require a search domain (e.g. `myhost.local`) depending on your network setup (corp
+vpn, home router settings)__
 
 Alternatively, you can set up the following:
 

--- a/tasks/terraform/README.md
+++ b/tasks/terraform/README.md
@@ -67,3 +67,45 @@ doesn't exist.
 The Terraform file used for the test will default
 the `src/test/terraform/main.tf` and the value for the `CONCORD_TMP_DIR`
 envar will be set for you if it is not present.
+
+### Payload Test
+
+Use [`testPayload.sh`](testPayload.sh) to test the task against a "real" Concord
+instance. It's still best for this to run locally in
+[Docker containers](https://concord.walmart.com/docs/getting-started/install/docker.html).
+
+This is, currently, the only way to test the `dockerImage` option.
+
+`testPayload.sh` can be configured with a number of environment variables.
+
+```shell
+SERVER_URL=http://localhost:8001 \
+  ORG=Default \
+  PROJECT=terraform-test \
+  TF_DOCKER_IMAGE=zenika/terraform-aws-cli:latest \
+  RUNTIME=v2 \
+  TF_VERSION=1.2.6 \
+  TF_FILE=./src/test/terraform/minimal_aws/main.tf \
+  ENTRY_POINT=fullTestCustomConfig \
+  EXTA_VARS_FILE=~/.aws/credentials.tfvars \
+  ./testPayload.sh
+```
+
+Optionally, the variables can be stored in a properties file. This makes usage
+a bit cleaner by storing the less-often changed variables out of sight.
+
+Examples properties file `~/.aws/.dev.aws.props`
+```properties
+SERVER_URL=http://localhost:8001
+ORG=Default
+PROJECT=terraform-test
+TF_DOCKER_IMAGE=hub.docker.prod.walmart.com/zenika/terraform-aws-cli:latest
+TF_FILE=./src/test/terraform/minimal_aws/main.tf
+EXTA_VARS_FILE=~/.aws/credentials.tfvars
+```
+
+Set a `PARAM_FILE` env var to let th script know where to load them from.
+
+```shell
+$ PARAM_FILE=.dev.aws.props ENTRY_POINT=fullTestCustomConfig RUNTIME=v1 ./testPayload.sh
+```

--- a/tasks/terraform/pom.xml
+++ b/tasks/terraform/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <skipTests>true</skipTests>
-        <testcontainers.concord.version>0.0.30</testcontainers.concord.version>
+        <testcontainers.concord.version>0.0.40</testcontainers.concord.version>
     </properties>
 
     <dependencies>

--- a/tasks/terraform/pom.xml
+++ b/tasks/terraform/pom.xml
@@ -95,9 +95,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
+            <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runner-v2</artifactId>
+            <version>${concord.version}</version>
         </dependency>
         <dependency>
             <groupId>ca.ibodrov.concord</groupId>

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TaskConstants.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TaskConstants.java
@@ -29,6 +29,7 @@ public final class TaskConstants {
     public static final String DEFAULT_ENV_KEY = "defaultEnv";
     public static final String DESTROY_KEY = "destroy";
     public static final String DIR_KEY = "dir";
+    public static final String DOCKER_IMAGE_KEY = "dockerImage";
     public static final String EXTRA_ENV_KEY = "extraEnv";
     public static final String EXTRA_VARS_KEY = "extraVars";
     public static final String GIT_SSH_KEY = "gitSsh";
@@ -51,7 +52,7 @@ public final class TaskConstants {
     public static final String TF_CLI_CONFIG_FILE_KEY = "TF_CLI_CONFIG_FILE";
 
     static final String[] ALL_IN_PARAMS = {ACTION_KEY, BACKEND_KEY, DEBUG_KEY, DEFAULT_ENV_KEY, DESTROY_KEY,
-            DIR_KEY, EXTRA_ENV_KEY, EXTRA_VARS_KEY, VARS_FILES, GIT_SSH_KEY, IGNORE_ERRORS_KEY, IGNORE_LOCAL_BINARY_KEY,
+            DIR_KEY, DOCKER_IMAGE_KEY, EXTRA_ENV_KEY, EXTRA_VARS_KEY, VARS_FILES, GIT_SSH_KEY, IGNORE_ERRORS_KEY, IGNORE_LOCAL_BINARY_KEY,
             MODULE_KEY, PLAN_KEY, PWD_KEY, RESULT_KEY, SAVE_OUTPUT_KEY, STATE_ID_KEY, VERBOSE_KEY, TARGET_KEY,
             TOOL_VERSION_KEY, TOOL_URL_KEY};
 

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Terraform.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Terraform.java
@@ -78,6 +78,10 @@ public class Terraform {
         this.dockerImage = dockerImage;
         this.dockerService = dockerService;
         this.version = getBinaryVersion();
+
+        if (dockerImage != null) {
+            log.info("Executing terraform commands in container using image: {}", dockerImage);
+        }
     }
 
     public Version version() {
@@ -135,7 +139,7 @@ public class Terraform {
         cmd.addAll(args.get());
 
         if (debug) {
-            log.info("exec -> {} in {}", String.join(" ", cmd), containerPwd);
+            log.info("exec -> {} in {}{}", String.join(" ", cmd), dockerImage, pwd);
         }
 
         Map<String, String> combinedEnv = new HashMap<>(baseEnv);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Terraform.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Terraform.java
@@ -52,7 +52,7 @@ public class Terraform {
     private final String dockerImage;
     private final TerraformDockerService dockerService;
 
-    public enum CLI_ACTION {
+    public enum CliAction {
         APPLY,
         DESTROY,
         INIT,
@@ -170,11 +170,11 @@ public class Terraform {
         return new Result(code, outLog.fullLog(), errLog.fullLog());
     }
 
-    public TerraformArgs buildArgs(CLI_ACTION action) {
+    public TerraformArgs buildArgs(CliAction action) {
         return new TerraformArgsImpl(action, null);
     }
 
-    public TerraformArgs buildArgs(CLI_ACTION action, Path targetDir) {
+    public TerraformArgs buildArgs(CliAction action, Path targetDir) {
         return new TerraformArgsImpl(action, targetDir);
     }
 
@@ -182,7 +182,7 @@ public class Terraform {
         private final List<String> args;
         private final boolean hasChdir;
 
-        public TerraformArgsImpl(CLI_ACTION action, Path targetDir) {
+        public TerraformArgsImpl(CliAction action, Path targetDir) {
             this.args = new LinkedList<>();
 
             hasChdir = targetDir != null && VersionUtils.ge(Terraform.this, 0, 14, 0);
@@ -231,7 +231,7 @@ public class Terraform {
     }
 
     private Version getBinaryVersion() throws Exception {
-        TerraformArgs args = buildArgs(CLI_ACTION.VERSION).add("-json");
+        TerraformArgs args = buildArgs(CliAction.VERSION).add("-json");
 
         Result result = exec(binary.getParent().toAbsolutePath(), "version",
                 !debug, Collections.emptyMap(), args);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Terraform.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Terraform.java
@@ -229,15 +229,6 @@ public class Terraform {
     private Version getBinaryVersion() throws Exception {
         TerraformArgs args = buildArgs(CLI_ACTION.VERSION).add("-json");
 
-//        // execute in container once to make sure image is already pulled
-//        if (dockerImage != null) {
-//            Result prepare = exec(binary.getParent().toAbsolutePath(), "version",
-//                    true, Collections.emptyMap(), args);
-//            if (prepare.getCode() != 0) {
-//                throw new RuntimeException("Failed to pull docker image for subsequent calls. Exit code " + prepare.getCode() + ": " + prepare.getStdout() + prepare.getStderr());
-//            }
-//        }
-
         Result result = exec(binary.getParent().toAbsolutePath(), "version",
                 !debug, Collections.emptyMap(), args);
         if (result.getCode() != 0) {

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformArgs.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformArgs.java
@@ -1,0 +1,54 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.nio.file.Path;
+import java.util.List;
+
+public interface TerraformArgs {
+    /** @return true if terraform version support -chdir option */
+    boolean hasChdir();
+    /** Add a Terraform CLI option (e.g. "-auto-approve", "-json") */
+    TerraformArgs add(String opt);
+
+    /**
+     * Add an option and value argument.
+     * @param opt Terraform CLI option (e.g. "-input")
+     * @param value Value for given option (e.g. "false")
+     */
+    TerraformArgs add(String opt, String value);
+
+    /**
+     * Add a path argument. Value will be translated to valid container path when
+     * executing in a container.
+     * @param path Absolute path within process' working directory
+     */
+    TerraformArgs add(Path path);
+
+    /**
+     * Add an option and path value argument. Value will be translated to valid
+     * container path when executing in a container.
+     * @param opt Terraform CLI option (e.g. "-var-file", "-out")
+     * @param path Absolute path within process' working directory
+     */
+    TerraformArgs add(String opt, Path path);
+    List<String> get();
+}

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformArgs.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformArgs.java
@@ -23,6 +23,13 @@ package com.walmartlabs.concord.plugins.terraform;
 import java.nio.file.Path;
 import java.util.List;
 
+/**
+ * Class for generating a collection of Terraform CLI arguments. Most can be
+ * added with the {@link #add(String)} and {@link #add(String, String)} methods.
+ * Arguments which contain a file path should be added with the {@link #add(Path)}
+ * or {@link #add(String, Path)} so the path can be relativized depending on
+ * where the <code>terraform</code> command is executed (e.g. local vs container)
+ */
 public interface TerraformArgs {
     /** @return true if terraform version support -chdir option */
     boolean hasChdir();
@@ -50,5 +57,10 @@ public interface TerraformArgs {
      * @param path Absolute path within process' working directory
      */
     TerraformArgs add(String opt, Path path);
+
+    /**
+     * @return Full list of <code>terraform</code> arguments in the order they
+     * were added.
+     */
     List<String> get();
 }

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformDockerService.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformDockerService.java
@@ -1,0 +1,127 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public interface TerraformDockerService {
+
+    int start(DockerContainerSpec spec,
+              Terraform.DockerLogCallback outLog,
+              Terraform.DockerLogCallback errLog) throws Exception;
+
+    class DockerContainerSpec {
+
+        private String image;
+        private List<String> args;
+        private Map<String, String> env;
+        private boolean debug;
+        private boolean forcePull;
+        private Collection<String> extraDockerHosts;
+        private int pullRetryCount;
+        private long pullRetryInterval;
+        private Path pwd;
+
+        public String image() {
+            return image;
+        }
+
+        public DockerContainerSpec image(String image) {
+            this.image = image;
+            return this;
+        }
+
+        public List<String> args() {
+            return args;
+        }
+
+        public DockerContainerSpec args(List<String> args) {
+            this.args = args;
+            return this;
+        }
+
+        public Map<String, String> env() {
+            return this.env;
+        }
+
+        public DockerContainerSpec env(Map<String, String> env) {
+            this.env = env;
+            return this;
+        }
+
+        public boolean debug() {
+            return this.debug;
+        }
+
+        public DockerContainerSpec debug(boolean debug) {
+            this.debug = debug;
+            return this;
+        }
+
+        public boolean forcePull() {
+            return this.forcePull;
+        }
+
+        public DockerContainerSpec forcePull(boolean forcePull) {
+            this.forcePull = forcePull;
+            return this;
+        }
+
+        public Collection<String> extraDockerHosts() {
+            return this.extraDockerHosts;
+        }
+
+        public DockerContainerSpec extraDockerHosts(Collection<String> extraDockerHosts) {
+            this.extraDockerHosts = extraDockerHosts;
+            return this;
+        }
+
+        public int pullRetryCount() {
+            return this.pullRetryCount;
+        }
+
+        public DockerContainerSpec pullRetryCount(int pullRetryCount) {
+            this.pullRetryCount = pullRetryCount;
+            return this;
+        }
+
+        public long pullRetryInterval() {
+            return this.pullRetryInterval;
+        }
+
+        public DockerContainerSpec pullRetryInterval(long pullRetryInterval) {
+            this.pullRetryInterval = pullRetryInterval;
+            return this;
+        }
+
+        public Path pwd() {
+            return this.pwd;
+        }
+
+        public DockerContainerSpec pwd(Path pwd) {
+            this.pwd = pwd;
+            return this;
+        }
+    }
+}

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformExecutable.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformExecutable.java
@@ -1,0 +1,33 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+import java.nio.file.Path;
+
+/**
+ * A Terraform executable file may exist in a number of contexts (local filesystem
+ * vs container filesystem) and may be detected in a shell PATH or explicitly
+ * added to a particular working directory. {@link TerraformExecutable}
+ * encapsulates these properties to help make sense of them in downstream usage
+ * of the executable
+ */
+public class TerraformExecutable {
+
+    final private Path executablePath;
+    final private boolean sourceInContainer;
+
+    public TerraformExecutable(Path executablePath, boolean sourceInContainer) {
+        this.executablePath = executablePath;
+        this.sourceInContainer = sourceInContainer;
+    }
+
+    public boolean isSourceInContainer() {
+        return sourceInContainer;
+    }
+
+    public Path getExecutablePath() {
+        return executablePath;
+    }
+
+    public boolean hasPath() {
+        return executablePath != null;
+    }
+}

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformExecutable.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformExecutable.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.plugins.terraform;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import java.nio.file.Path;
 
 /**

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTask.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTask.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.walmartlabs.concord.plugins.terraform.Terraform.CLI_ACTION.VERSION;
+import static com.walmartlabs.concord.plugins.terraform.Terraform.CliAction.VERSION;
 import static com.walmartlabs.concord.plugins.terraform.TerraformTaskCommon.*;
 
 @Named("terraform")

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2.java
@@ -101,7 +101,7 @@ public class TerraformTaskV2 implements Task {
                         logOut::onLog,
                         logErr::onLog));
         if (debug) {
-            terraform.exec(workDir, "version", terraform.buildArgs(Terraform.CLI_ACTION.VERSION));
+            terraform.exec(workDir, "version", terraform.buildArgs(Terraform.CliAction.VERSION));
         }
 
         try {

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/PlanAction.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/PlanAction.java
@@ -68,7 +68,7 @@ public class PlanAction extends Action {
             Path outFile = null;
             String outFileStr = null;
             if (backend.supportsOutFiles()) {
-                outFile = getOutFile(getPwd());
+                outFile = getOutFile(getWorkDir());
                 outFileStr = getPwd().relativize(outFile).toString();
             }
 

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/ApplyCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/ApplyCommand.java
@@ -52,7 +52,7 @@ public class ApplyCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.APPLY,
+        TerraformArgs args = terraform.buildArgs(Terraform.CliAction.APPLY,
                 (Files.isDirectory(dirOrPlan)) ? dirOrPlan : null);
 
         args.add("-input", "false");

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/ApplyCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/ApplyCommand.java
@@ -22,11 +22,10 @@ package com.walmartlabs.concord.plugins.terraform.commands;
 
 import com.walmartlabs.concord.plugins.terraform.Terraform;
 import com.walmartlabs.concord.plugins.terraform.Terraform.Result;
-import com.walmartlabs.concord.plugins.terraform.VersionUtils;
+import com.walmartlabs.concord.plugins.terraform.TerraformArgs;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -53,19 +52,16 @@ public class ApplyCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        List<String> args = new ArrayList<>();
-        boolean hasChdir = VersionUtils.ge(terraform, 0, 14, 0);
-        if (hasChdir && Files.isDirectory(dirOrPlan)) {
-            args.add("-chdir=" + dirOrPlan);
-        }
-        args.add("apply");
-        args.add("-input=false");
+        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.APPLY,
+                (Files.isDirectory(dirOrPlan)) ? dirOrPlan : null);
+
+        args.add("-input", "false");
         args.add("-auto-approve");
 
-        userSuppliedVarFiles.forEach(f -> args.add("-var-file=" + f.toAbsolutePath()));
+        userSuppliedVarFiles.forEach(f -> args.add("-var-file", f));
 
         if (Files.isRegularFile(dirOrPlan)) {
-            args.add(dirOrPlan.toString());
+            args.add(dirOrPlan);
         }
 
         return terraform.exec(pwd, "\u001b[35mapply\u001b[0m", false, env, args);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/DestroyCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/DestroyCommand.java
@@ -22,10 +22,9 @@ package com.walmartlabs.concord.plugins.terraform.commands;
 
 import com.walmartlabs.concord.plugins.terraform.Terraform;
 import com.walmartlabs.concord.plugins.terraform.Terraform.Result;
-import com.walmartlabs.concord.plugins.terraform.VersionUtils;
+import com.walmartlabs.concord.plugins.terraform.TerraformArgs;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -54,24 +53,19 @@ public class DestroyCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        List<String> args = new ArrayList<>();
-        boolean hasChdir = VersionUtils.ge(terraform, 0, 14, 0);
-        if (hasChdir) {
-            args.add("-chdir=" + dir.toString());
-        }
-        args.add("destroy");
-        args.add("-input=false");
+        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.DESTROY, dir);
+
+        args.add("-input", "false");
         args.add("-auto-approve");
 
         if (target != null) {
-            args.add("-target");
-            args.add(target);
+            args.add("-target", target);
         }
 
-        userSuppliedVarFiles.forEach(f -> args.add("-var-file=" + f.toAbsolutePath().toString()));
+        userSuppliedVarFiles.forEach(f -> args.add("-var-file", f));
 
-        if (!hasChdir) {
-            args.add(dir.toString());
+        if (!args.hasChdir()) {
+            args.add(dir);
         }
 
         return terraform.exec(pwd, "\u001b[35mdestroy\u001b[0m", false, env, args);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/DestroyCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/DestroyCommand.java
@@ -53,7 +53,7 @@ public class DestroyCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.DESTROY, dir);
+        TerraformArgs args = terraform.buildArgs(Terraform.CliAction.DESTROY, dir);
 
         args.add("-input", "false");
         args.add("-auto-approve");

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/InitCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/InitCommand.java
@@ -50,7 +50,7 @@ public class InitCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.INIT, dir);
+        TerraformArgs args = terraform.buildArgs(Terraform.CliAction.INIT, dir);
 
         args.add("-input", "false");
 

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/InitCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/InitCommand.java
@@ -20,14 +20,11 @@ package com.walmartlabs.concord.plugins.terraform.commands;
  * =====
  */
 
-import com.fasterxml.jackson.core.Version;
 import com.walmartlabs.concord.plugins.terraform.Terraform;
 import com.walmartlabs.concord.plugins.terraform.Terraform.Result;
-import com.walmartlabs.concord.plugins.terraform.VersionUtils;
+import com.walmartlabs.concord.plugins.terraform.TerraformArgs;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class InitCommand {
@@ -53,15 +50,12 @@ public class InitCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        List<String> args = new ArrayList<>();
-        boolean hasChdir = VersionUtils.ge(terraform, 0, 14, 0);
-        if (hasChdir) {
-            args.add("-chdir=" + dir.toString());
-        }
-        args.add("init");
-        args.add("-input=false");
-        if (!hasChdir) {
-            args.add(dir.toString());
+        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.INIT, dir);
+
+        args.add("-input", "false");
+
+        if (!args.hasChdir()) {
+            args.add(dir);
         }
 
         return terraform.exec(pwd, "\u001b[36minit\u001b[0m", silent, env, args);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/OutputCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/OutputCommand.java
@@ -51,7 +51,7 @@ public class OutputCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.OUTPUT);
+        TerraformArgs args = terraform.buildArgs(Terraform.CliAction.OUTPUT);
 
         args.add("-json");
 

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/OutputCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/OutputCommand.java
@@ -22,12 +22,11 @@ package com.walmartlabs.concord.plugins.terraform.commands;
 
 import com.walmartlabs.concord.plugins.terraform.Terraform;
 import com.walmartlabs.concord.plugins.terraform.Terraform.Result;
+import com.walmartlabs.concord.plugins.terraform.TerraformArgs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class OutputCommand {
@@ -52,15 +51,15 @@ public class OutputCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        List<String> args = new ArrayList<>();
-        args.add("output");
+        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.OUTPUT);
+
         args.add("-json");
 
         if (module != null) {
             if (debug) {
                 log.info("exec -> using module: {}", module);
             }
-            args.add("-module=" + module);
+            args.add("-module", module);
         }
 
         return terraform.exec(pwd, "\u001b[33moutput\u001b[0m", false, env, args);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/PlanCommand.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/commands/PlanCommand.java
@@ -64,7 +64,7 @@ public class PlanCommand {
     }
 
     public Result exec(Terraform terraform) throws Exception {
-        TerraformArgs args = terraform.buildArgs(Terraform.CLI_ACTION.PLAN, dirOrPlan);
+        TerraformArgs args = terraform.buildArgs(Terraform.CliAction.PLAN, dirOrPlan);
 
         args.add("-input", "false");
         args.add("-detailed-exitcode");

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/AbstractTerraformTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/AbstractTerraformTest.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.plugins.terraform;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.extension.Parameters;
@@ -15,7 +35,6 @@ import com.walmartlabs.concord.common.IOUtils;
 import com.walmartlabs.concord.plugins.terraform.backend.BackendFactoryV1;
 import com.walmartlabs.concord.plugins.terraform.docker.DockerService;
 import com.walmartlabs.concord.sdk.*;
-import org.intellij.lang.annotations.Language;
 import org.junit.Rule;
 
 import java.io.*;
@@ -394,10 +413,10 @@ public abstract class AbstractTerraformTest {
         }
     }
 
-    public static void assertOutput(@Language("RegExp") String pattern, String input) {
-        String msg = "Expected: " + pattern + "\n"
+    public static void assertOutput(String regexPattern, String input) {
+        String msg = "Expected: " + regexPattern + "\n"
                 + "Got: " + input;
-        assertEquals(msg, 1, grep(pattern, input).size());
+        assertEquals(msg, 1, grep(regexPattern, input).size());
     }
 
     public static List<String> grep(String pattern, String input) {

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/AbstractTerraformTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/AbstractTerraformTest.java
@@ -1,0 +1,415 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import com.walmartlabs.concord.common.IOUtils;
+import com.walmartlabs.concord.plugins.terraform.backend.BackendFactoryV1;
+import com.walmartlabs.concord.plugins.terraform.docker.DockerService;
+import com.walmartlabs.concord.sdk.*;
+import org.intellij.lang.annotations.Language;
+import org.junit.Rule;
+
+import java.io.*;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+public abstract class AbstractTerraformTest {
+    protected final static String CONCORD_TMP_DIR_KEY = "CONCORD_TMP_DIR";
+    protected final static String CONCORD_TMP_DIR_VALUE = "/tmp/concord";
+    protected final static String CONCORD_AWS_CREDENTIALS_KEY = "concord-integration-tests";
+
+    private String basedir;
+
+    private AWSCredentials awsCredentials;
+    protected Path workDir;
+    protected Path dstDir;
+    private Path testFile;
+    private Path downloadManagerCacheDir;
+    protected LockService lockService;
+    protected ObjectStorage objectStorage;
+    protected BackendFactoryV1 backendManager;
+    protected OKHttpDownloadManager dependencyManager;
+    protected DockerService dockerService;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig()
+            .extensions(new StateBackendTransformer())
+            .bindAddress("0.0.0.0")
+            .port(12345));
+
+    public void abstractSetup() throws Exception {
+        basedir = new File("").getAbsolutePath();
+
+        awsCredentials = awsCredentials();
+        workDir = workDir();
+        testFile = terraformTestFile();
+        downloadManagerCacheDir = Paths.get("/tmp/downloadManager/cache");
+        Files.createDirectories(downloadManagerCacheDir);
+
+        System.out.println("Using the following:");
+        System.out.println();
+        System.out.println("AWS Access Key ID: " + awsCredentials.accessKey);
+        System.out.println("   AWS Secret Key: " + awsCredentials.secretKey);
+        System.out.println("   Terraform file: " + testFile);
+        System.out.println("          workDir: " + workDir);
+        System.out.println();
+
+        Files.createDirectories(workDir);
+        dstDir = workDir;
+        Files.copy(testFile, dstDir.resolve("main.tf"));
+
+        lockService = mock(LockService.class);
+        dependencyManager = new OKHttpDownloadManager("terraform");
+        dockerService = new DockerService(workDir, Collections.emptyList());
+    }
+
+    /**
+     * Unsophisticated shorthand for digging into a number of nested map. Won't
+     * work if there's a List somewhere in the middle. but hte final value can
+     * be any object
+     */
+    @SuppressWarnings("unchecked")
+    protected static <T> T findInMap(Map<String, Object> m, String path) {
+        String[] keys = path.split("\\.");
+        if (keys.length == 1) {
+            return (T) m.get(keys[0]);
+        }
+
+        return findInMap(MapUtils.assertMap(m, keys[0]), path.substring(path.indexOf(".") + 1));
+    }
+
+    protected Map<String, Object> extraVars() {
+        Map<String, Object> extraVars = new HashMap<>();
+        extraVars.put("aws_access_key", awsCredentials.accessKey);
+        extraVars.put("aws_secret_key", awsCredentials.secretKey);
+        return extraVars;
+    }
+
+    protected List<String> varFiles() throws Exception {
+        //
+        // We place our user supplied var files in the workspace and they are declared as being relative
+        // to the Concord workspace. So we copy them into the workspace at the root so we just refer to
+        // them as "varfile0.tfvars" and varfile1.tfvars.
+        //
+        Path varfile0 = varFile("varfile0.tfvars");
+        Files.copy(varfile0, dstDir.resolve(varfile0.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+        Path varfile1 = varFile("varfile1.tfvars");
+        Files.copy(varfile1, dstDir.resolve(varfile1.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+
+        return new ArrayList<>(Arrays.asList("varfile0.tfvars", "varfile1.tfvars"));
+    }
+
+    protected Map<String, Object> gitSsh() throws Exception {
+        Map<String, Object> gitSsh = new HashMap<>();
+        gitSsh.put(GitSshWrapper.PRIVATE_KEYS_KEY, Collections.singletonList(Files.createTempFile("test", ".key").toAbsolutePath().toString()));
+        gitSsh.put(GitSshWrapper.SECRETS_KEY, Collections.singletonList(Collections.singletonMap("secretName", "test")));
+        return gitSsh;
+    }
+
+    /**
+     * @return API host name (no port, not a URL) on usage of docker container (or not)
+     */
+    protected static String apiHostName() {
+        String fromEnv = System.getenv("TF_TEST_HOSTNAME");
+        if (fromEnv != null) {
+            return fromEnv;
+        }
+
+        return dockerImage().isPresent() ?  "host.docker.internal" : "localhost";
+    }
+
+    public static class StateBackendTransformer extends ResponseTransformer {
+        private String lastJsonState;
+
+        @Override
+        public com.github.tomakehurst.wiremock.http.Response transform(com.github.tomakehurst.wiremock.http.Request request,
+                                                                       com.github.tomakehurst.wiremock.http.Response response,
+                                                                       FileSource files,
+                                                                       Parameters parameters) {
+
+            if (request.getMethod().equals(RequestMethod.POST)) {
+                if (!response.getHeaders().keys().contains("keep_payload")) {
+                    fail("Unexpected POST response. No 'keep_payload' header. Double-check default stub(s)");
+                }
+
+                HttpHeader hdr = response.getHeaders().getHeader("keep_payload");
+                boolean keep_payload = Boolean.parseBoolean(hdr.values().get(0));
+
+
+                if (keep_payload) {
+                    // TODO: persist in a semi-recoverable file?
+                    lastJsonState = request.getBodyAsString();
+                }
+            }
+
+            if (request.getMethod().equals(RequestMethod.GET) && lastJsonState != null) {
+                return com.github.tomakehurst.wiremock.http.Response.response()
+                        .status(200)
+                        .body(lastJsonState)
+                        .build();
+            }
+
+            return response;
+        }
+
+        @Override
+        public String getName() {
+            return "state-backend-transformer";
+        }
+    }
+
+    protected Map<String, Object> baseArguments(Path workDir, Path dstDir, String actionKey) {
+        Map<String, Object> args = new HashMap<>();
+        args.put(Constants.Request.PROCESS_INFO_KEY, Collections.singletonMap("sessionKey", "xyz"));
+        args.put(Constants.Context.WORK_DIR_KEY, workDir.toAbsolutePath().toString());
+        args.put(TaskConstants.ACTION_KEY, actionKey);
+        args.put(TaskConstants.DEBUG_KEY, true);
+        args.put(TaskConstants.STATE_ID_KEY, "testState");
+        args.put(TaskConstants.DIR_KEY, dstDir.toAbsolutePath().toString());
+        dockerImage().ifPresent(image -> args.put("dockerImage", image));
+        return args;
+    }
+
+    private Path varFile(String name) {
+        return new File(basedir, "src/test/terraform/" + name).toPath();
+    }
+
+    protected String responseTemplate(String name) throws IOException {
+        return new String(Files.readAllBytes(new File(basedir, "src/test/terraform/" + name).toPath()));
+    }
+
+    //
+    // Helpers for using AWS credentials in ~/.aws/credentials
+    //
+
+    private AWSCredentials awsCredentials() {
+        AWSCredentials awsCredentials = new AWSCredentials();
+        File awsCredentialsFile = new File(System.getProperty("user.home"), ".aws/credentials");
+        if (awsCredentialsFile.exists()) {
+            Map<String, Properties> awsCredentialsIni = parseIni(awsCredentialsFile);
+            if (awsCredentialsIni != null) {
+                Properties concordAwsCredentials = awsCredentialsIni.get(CONCORD_AWS_CREDENTIALS_KEY);
+                awsCredentials.accessKey = concordAwsCredentials.getProperty("aws_access_key_id");
+                awsCredentials.secretKey = concordAwsCredentials.getProperty("aws_secret_access_key");
+            }
+        }
+
+        if (awsCredentials.accessKey.isEmpty() && awsCredentials.secretKey.isEmpty()) {
+            awsCredentials.accessKey = System.getenv("AWS_ACCESS_KEY");
+            if (awsCredentials.accessKey == null) {
+                awsCredentials.accessKey = System.getenv("AWS_ACCESS_KEY_ID");
+            }
+            awsCredentials.secretKey = System.getenv("AWS_SECRET_KEY");
+            if (awsCredentials.secretKey == null) {
+                awsCredentials.secretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+            }
+        }
+
+        if (awsCredentials.accessKey.isEmpty() && awsCredentials.secretKey.isEmpty()) {
+            throw new RuntimeException(String.format("An AWS access key id and secret key must be set using envars or the ~/.aws/credentials file with the %s profile.", CONCORD_AWS_CREDENTIALS_KEY));
+        }
+
+        return awsCredentials;
+    }
+
+    private static class AWSCredentials {
+        String accessKey;
+        String secretKey;
+
+        AWSCredentials() {
+            this.accessKey = "";
+            this.secretKey = "";
+        }
+
+        @Override
+        public String toString() {
+            return "AWSCredentials{" +
+                    "accessKey='" + accessKey + '\'' +
+                    ", secretKey='" + secretKey + '\'' +
+                    '}';
+        }
+    }
+
+    private static Map<String, Properties> parseIni(File file) {
+        try (Reader reader = new FileReader(file)) {
+            Map<String, Properties> result = new HashMap();
+            new Properties() {
+
+                private Properties section;
+
+                @Override
+                public Object put(Object key, Object value) {
+                    String header = (key + " " + value).trim();
+                    if (header.startsWith("[") && header.endsWith("]")) {
+                        return result.put(header.substring(1, header.length() - 1), section = new Properties());
+                    } else {
+                        return section.put(key, value);
+                    }
+                }
+
+            }.load(reader);
+            return result;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    //
+    // Helpers for setting envars and setting CONCORD_TMP_DIR envar
+    //
+
+    private Path workDir() throws Exception {
+        String concordTmpDir = System.getenv(CONCORD_TMP_DIR_KEY);
+        if (concordTmpDir == null) {
+            // Grab the old environment and add the CONCORD_TMP_DIR value to it and reset it
+            Map<String, String> newEnvironment = new HashMap();
+            newEnvironment.putAll(System.getenv());
+            newEnvironment.put(CONCORD_TMP_DIR_KEY, CONCORD_TMP_DIR_VALUE);
+            setNewEnvironment(newEnvironment);
+        }
+        return IOUtils.createTempDir("test");
+    }
+
+    private Path terraformTestFile() {
+        String terraformTestFileEnvVar = System.getenv("TF_TEST_FILE");
+        if (terraformTestFileEnvVar != null) {
+            return Paths.get(System.getenv("TF_TEST_FILE"));
+        }
+        // Use the test terraform file we have in the repository
+        return new File(basedir, "src/test/terraform/main.tf").toPath();
+    }
+
+    protected static Optional<String> dockerImage() {
+        String dockerImageEnvVar = System.getenv("TF_TEST_DOCKER_IMAGE");
+        if (dockerImageEnvVar != null && !dockerImageEnvVar.isEmpty()) {
+            return Optional.of(dockerImageEnvVar);
+        }
+
+        return Optional.empty();
+    }
+
+    private static void setNewEnvironment(Map<String, String> newEnvironment) throws Exception {
+        try {
+            Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
+            Field theEnvironmentField = processEnvironmentClass.getDeclaredField("theEnvironment");
+            theEnvironmentField.setAccessible(true);
+            Map<String, String> env = (Map<String, String>) theEnvironmentField.get(null);
+            env.putAll(newEnvironment);
+            Field theCaseInsensitiveEnvironmentField = processEnvironmentClass.getDeclaredField("theCaseInsensitiveEnvironment");
+            theCaseInsensitiveEnvironmentField.setAccessible(true);
+            Map<String, String> cienv = (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
+            cienv.putAll(newEnvironment);
+        } catch (NoSuchFieldException e) {
+            Class[] classes = Collections.class.getDeclaredClasses();
+            Map<String, String> env = System.getenv();
+            for (Class cl : classes) {
+                if ("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
+                    Field field = cl.getDeclaredField("m");
+                    field.setAccessible(true);
+                    Object obj = field.get(env);
+                    Map<String, String> map = (Map<String, String>) obj;
+                    map.clear();
+                    map.putAll(newEnvironment);
+                }
+            }
+        }
+    }
+
+    static class OKHttpDownloadManager implements DependencyManager, com.walmartlabs.concord.runtime.v2.sdk.DependencyManager {
+
+        private final Path toolDir;
+
+        public OKHttpDownloadManager(String tool) {
+            this.toolDir = Paths.get(System.getProperty("user.home"), ".m2/tools/", tool);
+
+            if (Files.exists(toolDir)) {
+                return;
+            }
+
+            Set<PosixFilePermission> perms =
+                    PosixFilePermissions.fromString("rwxr-x---");
+
+            if (Files.exists(toolDir)) {
+                return;
+            }
+
+
+            try {
+                if (!Files.exists(Files.createDirectories(toolDir, PosixFilePermissions.asFileAttribute(perms)))) {
+                    throw new Exception("Failed to crate tool cache directory: " + toolDir);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to create cache directory for terraform executable.");
+            }
+        }
+
+        @Override
+        public Path resolve(URI uri) throws IOException {
+            String urlString = uri.toString();
+            String fileName = urlString.substring(urlString.lastIndexOf('/') + 1);
+            Path target = toolDir.resolve(fileName);
+            if (!Files.exists(target)) {
+                OkHttpClient client = new OkHttpClient();
+                Request request = new Request.Builder().url(urlString).build();
+                Call call = client.newCall(request);
+                Response response = call.execute();
+                download(response.body().byteStream(), target.toFile());
+            }
+            return target;
+        }
+
+        //
+        // https://stackoverflow.com/questions/309424/how-do-i-read-convert-an-inputstream-into-a-string-in-java
+        //
+        // surprised this is the fastest way to convert an inputstream to a string
+        //
+        private void download(InputStream stream, File target) throws IOException {
+            byte[] buffer = new byte[1024];
+            int length;
+            try (OutputStream result = new FileOutputStream(target)) {
+                while ((length = stream.read(buffer)) != -1) {
+                    result.write(buffer, 0, length);
+                }
+            }
+        }
+    }
+
+    public static void assertOutput(@Language("RegExp") String pattern, String input) {
+        String msg = "Expected: " + pattern + "\n"
+                + "Got: " + input;
+        assertEquals(msg, 1, grep(pattern, input).size());
+    }
+
+    public static List<String> grep(String pattern, String input) {
+        List<String> result = new ArrayList<>();
+
+        for (String line : input.split("\n")) {
+            if (line.matches(pattern)) {
+                result.add(line);
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTest.java
@@ -37,6 +37,8 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
 
 //

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTest.java
@@ -42,14 +42,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
 
 //
-// To run this test you need to set the following envars set:
+// To run this test you need to set the following env vars set:
 //
 // CONCORD_TMP_DIR      = /tmp/concord
 // AWS_ACCESS_KEY       = <your_aws_access_key>
 // AWS_SECRET_KEY       = <your_aws_secret_key>
+// PRIVATE_KEY_PATH     = <your_aws_pem_file>
 // TF_TEST_FILE	        = <path_to>/concord-plugins/tasks/terraform/src/test/terraform/main.tf or another file you want to test
 // TF_TEST_DOCKER_IMAGE = docker image in which to execute terraform
-// PRIVATE_KEY_PATH     = <your_aws_pem_file>
+// TF_TEST_HOSTNAME     = local hostname that's compatible both inside and outside a docker container
+// TF_TOOL_URL          = optional, terraform binary zip URL
 //
 // Alternatively you can use the following:
 //

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTestV2.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTestV2.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.plugins.terraform;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import com.squareup.okhttp.OkHttpClient;
 import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.client.ApiClientConfiguration;

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTestV2.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTestV2.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
 
 //
-// To run this test you need to set the following envars set:
+// To run this test you need to set the following env vars set:
 //
 // CONCORD_TMP_DIR      = /tmp/concord
 // AWS_ACCESS_KEY       = <your_aws_access_key>
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.*;
 // TF_TEST_FILE	        = <path_to>/concord-plugins/tasks/terraform/src/test/terraform/main.tf or another file you want to test
 // TF_TEST_DOCKER_IMAGE = docker image in which to execute terraform
 // TF_TEST_HOSTNAME     = local hostname that's compatible both inside and outside a docker container
+// TF_TOOL_URL          = optional, terraform binary zip URL
 //
 // Alternatively you can use the following:
 //
@@ -94,15 +95,12 @@ public class TerraformTaskTestV2 extends AbstractTerraformTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void test() throws Exception {
         Map<String, Object> args = baseArguments(workDir, dstDir, Action.PLAN.name());
         args.put(TaskConstants.VARS_FILES, varFiles());
         args.put(TaskConstants.EXTRA_VARS_KEY, extraVars());
         args.put(TaskConstants.GIT_SSH_KEY, gitSsh());
 
-
-//        String hostname = "m-c02x7b64jg5j.local";
         String hostname = apiHostName();
         String apiBaseUrl = String.format("http://%s:%s", hostname, wireMockRule.port());
 

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTestV2.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskTestV2.java
@@ -1,0 +1,230 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+import com.squareup.okhttp.OkHttpClient;
+import com.walmartlabs.concord.ApiClient;
+import com.walmartlabs.concord.client.ApiClientConfiguration;
+import com.walmartlabs.concord.client.ApiClientFactory;
+import com.walmartlabs.concord.client.ConcordApiClient;
+import com.walmartlabs.concord.runtime.v2.sdk.*;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+
+//
+// To run this test you need to set the following envars set:
+//
+// CONCORD_TMP_DIR      = /tmp/concord
+// AWS_ACCESS_KEY       = <your_aws_access_key>
+// AWS_SECRET_KEY       = <your_aws_secret_key>
+// PRIVATE_KEY_PATH     = <your_aws_pem_file>
+// TF_TEST_FILE	        = <path_to>/concord-plugins/tasks/terraform/src/test/terraform/main.tf or another file you want to test
+// TF_TEST_DOCKER_IMAGE = docker image in which to execute terraform
+// TF_TEST_HOSTNAME     = local hostname that's compatible both inside and outside a docker container
+//
+// Alternatively you can use the following:
+//
+// - An ~/.aws/credentials with a [concord-integration-tests] stanza where the access key id and secret key will be taken from
+// - The default src/test/terraform/main.tf test file
+// - A ~/.aws/conconrd-integration-tests.pem that will be used as the private key
+// - The CONCORD_TMP_DIR envar will be set for you to /tmp/concord
+//
+// Once setup this should just allow you to run the test.
+//
+// TODO: need to test destroy, computes are left in AWS
+// TODO: split test apart to prepare for testing OCI/GCP
+//
+@Ignore
+public class TerraformTaskTestV2 extends AbstractTerraformTest {
+    private ApiClient apiClient;
+    private SecretService secretService;
+    private final LockService lockService = mock(LockService.class);
+
+    @Before
+    public void setup() throws Exception {
+        abstractSetup();
+        secretService = createSecretService(workDir);
+
+        wireMockRule.stubFor(get(urlPathMatching("/api/v1/org/.*/jsonstore/.*"))
+                .willReturn(aResponse()
+                        .withHeader("keep_payload", Boolean.FALSE.toString())
+                        .withStatus(404)));
+        wireMockRule.stubFor(post(urlPathMatching("/api/v1/org/.*/jsonstore"))
+                .willReturn(aResponse()
+                        .withHeader("keep_payload", Boolean.FALSE.toString())
+                        .withStatus(200)));
+        wireMockRule.stubFor(post(urlPathMatching("/api/v1/org/.*/jsonstore/.*"))
+                .willReturn(aResponse()
+                        .withHeader("keep_payload", Boolean.TRUE.toString())
+                        .withStatus(200)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test() throws Exception {
+        Map<String, Object> args = baseArguments(workDir, dstDir, Action.PLAN.name());
+        args.put(TaskConstants.VARS_FILES, varFiles());
+        args.put(TaskConstants.EXTRA_VARS_KEY, extraVars());
+        args.put(TaskConstants.GIT_SSH_KEY, gitSsh());
+
+
+//        String hostname = "m-c02x7b64jg5j.local";
+        String hostname = apiHostName();
+        String apiBaseUrl = String.format("http://%s:%s", hostname, wireMockRule.port());
+
+        apiClient = getApiClientFactory().create(ApiClientConfiguration.builder()
+                .baseUrl(apiBaseUrl)
+                .build());
+
+        TaskResult.SimpleResult result = (TaskResult.SimpleResult) task(args)
+                .execute(new MapBackedVariables(args));
+
+        // ---
+
+        assertTrue(result.ok());
+        assertNotNull(result.values().get("planPath"));
+
+        // ---
+
+        verify(lockService, times(1)).projectLock(any());
+        verify(lockService, times(1)).projectUnlock(any());
+
+        // ---
+
+        System.out.println("===================================================================================");
+
+        args = baseArguments(workDir, dstDir, Action.APPLY.name());
+        args.put(TaskConstants.DESTROY_KEY, true);
+        args.put(TaskConstants.PLAN_KEY, result.values().get("planPath"));
+
+        result = (TaskResult.SimpleResult) task(args).execute(new MapBackedVariables(args));
+        System.out.println(result);
+
+        //
+        // Check the output contains our two variables populated with values from our var files
+        //
+        // Outputs:
+        //
+        // message = "hello!"
+        // name_from_varfile0 = "bob"
+        // time_from_varfile1 = "now"
+        //
+        assertOutput(".*name_from_varfile0 = \"?bob\"?.*", ((String) result.values().get("output")));
+        assertOutput(".*time_from_varfile1 = \"?now\"?.*", ((String) result.values().get("output")));
+
+        // ---
+
+        System.out.println("===================================================================================");
+
+        //
+        // Simulate having some outputs being created in the terraform state. The output action will not work
+        // correctly without outputs present in the terraform state.
+        //
+        String terraformStateWithOutputs = responseTemplate("terraform.tfstate");
+        wireMockRule.stubFor(get("/test").willReturn(aResponse().withBody(terraformStateWithOutputs).withStatus(200)));
+
+        args = baseArguments(workDir, dstDir, Action.OUTPUT.name());
+        result = (TaskResult.SimpleResult) task(args).execute(new MapBackedVariables(args));
+
+        // Validate expected output values were returned in 'data' attribute/key of 'result' variable
+        String nameResult = findInMap(result.values(), "data.name_from_varfile0.value");
+        String timeResult = findInMap(result.values(), "data.time_from_varfile1.value");
+
+        assertEquals("bob", nameResult);
+        assertEquals("now", timeResult);
+
+
+        //
+        // Cleanup time. State should be saved by our custom wiremock transformer.
+        // Without the state, terraform won't actually delete the resource(s)
+        args = baseArguments(workDir, dstDir, Action.DESTROY.name());
+        args.put(TaskConstants.VARS_FILES, varFiles());
+        args.put(TaskConstants.EXTRA_VARS_KEY, extraVars());
+        result = (TaskResult.SimpleResult) task(args).execute(new MapBackedVariables(args));
+
+        // Validate result
+        assertTrue(result.ok());
+
+    }
+
+    private TerraformTaskV2 task(Map<String, Object> args) {
+        return new TerraformTaskV2(initCtx(args), apiClient, secretService, lockService,
+                dependencyManager, dockerService);
+    }
+
+    private Context initCtx(Map<String, Object> args) {
+        ProjectInfo projectInfo = mock(ProjectInfo.class);
+        when(projectInfo.orgName()).thenReturn("test-org");
+
+        ProcessInfo processInfo = mock(ProcessInfo.class);
+        when(processInfo.sessionToken()).thenReturn("faketoken");
+
+        ProcessConfiguration processCfg = mock(ProcessConfiguration.class);
+        when(processCfg.projectInfo()).thenReturn(projectInfo);
+        when(processCfg.processInfo()).thenReturn(processInfo);
+
+        Context ctx = mock(Context.class);
+        when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.emptyMap())); // policy-defaults
+        when(ctx.variables()).thenReturn(new MapBackedVariables(Collections.emptyMap())); // process defaults (e.g. configuration.arguments
+        when(ctx.secretService()).thenReturn(secretService);
+        when(ctx.workingDirectory()).thenReturn(workDir);
+
+        when(ctx.processConfiguration()).thenReturn(processCfg);
+        when(ctx.processConfiguration().projectInfo()).thenReturn(projectInfo);
+
+        return ctx;
+    }
+
+    private static SecretService createSecretService(Path workDir) throws Exception {
+        String pemFileEnvar = System.getenv("PRIVATE_KEY_PATH");
+        Path dst = Files.createTempFile(workDir, "private", ".key");
+        if (pemFileEnvar != null) {
+            Files.copy(Paths.get(pemFileEnvar), dst, StandardCopyOption.REPLACE_EXISTING);
+        } else {
+            // Look for an ~/.aws/concord-integration-tests.pem file
+            File pemFile = new File(System.getProperty("user.hom"), ".aws/" + CONCORD_AWS_CREDENTIALS_KEY + ".pem");
+            if (pemFile.exists()) {
+                Files.copy(pemFile.toPath(), dst, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+
+        Map<String, String> m = Collections.singletonMap("private", workDir.relativize(dst).toString());
+
+        SecretService ss = mock(SecretService.class);
+        Mockito.doAnswer(invocationOnMock -> SecretService.KeyPair.builder()
+                .privateKey(dst)
+                .publicKey(Paths.get("we/dont/care"))
+                .build()).when(ss).exportKeyAsFile(any(), any(), any());
+
+        return ss;
+
+    }
+
+    ApiClientFactory getApiClientFactory() {
+        return cfg -> {
+            ApiClient apiClient = new ConcordApiClient(cfg.baseUrl(), new OkHttpClient());
+            apiClient.setReadTimeout(60000);
+            apiClient.setConnectTimeout(10000);
+            apiClient.setWriteTimeout(60000);
+
+            apiClient.addDefaultHeader("X-Concord-Trace-Enabled", "true");
+
+            apiClient.setApiKey(cfg.apiKey());
+            return apiClient;
+        };
+    }
+}

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerContainerSpecV1Compat.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerContainerSpecV1Compat.java
@@ -1,0 +1,115 @@
+package com.walmartlabs.concord.plugins.terraform.docker;
+
+import com.walmartlabs.concord.runtime.v2.sdk.DockerContainerSpec;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+public class DockerContainerSpecV1Compat implements DockerContainerSpec {
+
+    com.walmartlabs.concord.sdk.DockerContainerSpec specV1;
+
+    public DockerContainerSpecV1Compat(com.walmartlabs.concord.sdk.DockerContainerSpec specV1) {
+        this.specV1 = specV1;
+    }
+
+    public String image() {
+        return specV1.image();
+    }
+
+    @Nullable
+    public String name() {
+        return specV1.name();
+    }
+
+    @Nullable
+    public String user() {
+        return specV1.user();
+    }
+
+    @Nullable
+    public String workdir() {
+        return specV1.workdir();
+    }
+
+    @Nullable
+    public String entryPoint() {
+        return specV1.entryPoint();
+    }
+
+    @Nullable
+    public String cpu() {
+        return specV1.cpu();
+    }
+
+    @Nullable
+    public String memory() {
+        return specV1.memory();
+    }
+
+    @Nullable
+    public String stdOutFilePath() {
+        return specV1.stdOutFilePath();
+    }
+
+    @Nullable
+    public List<String> args() {
+        return specV1.args();
+    }
+
+    @Nullable
+    public Map<String, String> env() {
+        return specV1.env();
+    }
+
+    @Nullable
+    public String envFile() {
+        return specV1.envFile();
+    }
+
+    @Nullable
+    public Map<String, String> labels() {
+        return specV1.labels();
+    }
+
+    @Nullable
+    @Override
+    public Options options() {
+
+        if (specV1.options() == null) {
+            return null;
+        }
+
+        // Convert runtime-v1 docker options object to runtime-v2
+        com.walmartlabs.concord.sdk.DockerContainerSpec.Options o = specV1.options();
+
+        if (o == null || o.hosts() == null) {
+            return null;
+        }
+
+        return Options.builder()
+                .hosts(o.hosts())
+                .build();
+    }
+
+    public int pullRetryCount() {
+        return specV1.pullRetryCount();
+    }
+
+    public long pullRetryInterval() {
+        return specV1.pullRetryInterval();
+    }
+
+    public boolean debug() {
+        return specV1.debug();
+    }
+
+    public boolean forcePull() {
+        return specV1.forcePull();
+    }
+
+    public boolean redirectErrorStream() {
+        return specV1.redirectErrorStream();
+    }
+}

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerContainerSpecV1Compat.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerContainerSpecV1Compat.java
@@ -1,7 +1,26 @@
 package com.walmartlabs.concord.plugins.terraform.docker;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import com.walmartlabs.concord.runtime.v2.sdk.DockerContainerSpec;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -18,62 +37,50 @@ public class DockerContainerSpecV1Compat implements DockerContainerSpec {
         return specV1.image();
     }
 
-    @Nullable
     public String name() {
         return specV1.name();
     }
 
-    @Nullable
     public String user() {
         return specV1.user();
     }
 
-    @Nullable
     public String workdir() {
         return specV1.workdir();
     }
 
-    @Nullable
     public String entryPoint() {
         return specV1.entryPoint();
     }
 
-    @Nullable
     public String cpu() {
         return specV1.cpu();
     }
 
-    @Nullable
     public String memory() {
         return specV1.memory();
     }
 
-    @Nullable
     public String stdOutFilePath() {
         return specV1.stdOutFilePath();
     }
 
-    @Nullable
     public List<String> args() {
         return specV1.args();
     }
 
-    @Nullable
     public Map<String, String> env() {
         return specV1.env();
     }
 
-    @Nullable
     public String envFile() {
         return specV1.envFile();
     }
 
-    @Nullable
     public Map<String, String> labels() {
         return specV1.labels();
     }
 
-    @Nullable
     @Override
     public Options options() {
 

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerService.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerService.java
@@ -1,0 +1,173 @@
+package com.walmartlabs.concord.plugins.terraform.docker;
+
+import com.walmartlabs.concord.common.TruncBufferedReader;
+import com.walmartlabs.concord.runtime.v2.runner.DockerProcessBuilder;
+import com.walmartlabs.concord.runtime.v2.sdk.DockerContainerSpec;
+import com.walmartlabs.concord.sdk.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class DockerService implements com.walmartlabs.concord.sdk.DockerService, com.walmartlabs.concord.runtime.v2.sdk.DockerService {
+    private static final Logger log = LoggerFactory.getLogger(DockerService.class);
+
+    private static final int SUCCESS_EXIT_CODE = 0;
+    private static final String WORKSPACE_TARGET_DIR = "/workspace";
+
+    private final Path workingDirectory;
+    private final List<String> extraVolumes;
+
+    private static final Pattern[] REGISTRY_ERROR_PATTERNS = {
+            Pattern.compile("Error response from daemon.*received unexpected HTTP status: 5.*"),
+            Pattern.compile("Error response from daemon.*Get.*connection refused.*"),
+            Pattern.compile("Error response from daemon.*Client.Timeout exceeded.*")
+    };
+
+    public DockerService(Path workingDirectory, List<String> extraVolumes) {
+        this.workingDirectory = workingDirectory;
+        this.extraVolumes = extraVolumes;
+    }
+
+    @Override
+    public Process start(Context ctx, com.walmartlabs.concord.sdk.DockerContainerSpec spec) throws IOException {
+        throw new RuntimeException("deprecated. not implemented.");
+    }
+
+    @Override
+    public int start(Context ctx, com.walmartlabs.concord.sdk.DockerContainerSpec specV1,
+                     com.walmartlabs.concord.sdk.DockerService.LogCallback outCallback,
+                     com.walmartlabs.concord.sdk.DockerService.LogCallback errCallback)
+            throws IOException, InterruptedException {
+        return start(new DockerContainerSpecV1Compat(specV1), outCallback::onLog, errCallback::onLog);
+    }
+
+    @Override
+    public int start(DockerContainerSpec spec,
+                      com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback outCallback,
+                      com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback errCallback) throws IOException, InterruptedException {
+        int tryCount = 0;
+        int result;
+        int retryCount = Math.max(spec.pullRetryCount(), 0);
+        long retryInterval = spec.pullRetryInterval();
+
+        do {
+            try (DockerProcessBuilder.DockerProcess dp = build(spec)) {
+                Process p = dp.start();
+
+                LogCapture c = new LogCapture(outCallback);
+                streamToLog(p.getInputStream(), c);
+                if (errCallback != null) {
+                    streamToLog(p.getErrorStream(), errCallback);
+                }
+
+                result = p.waitFor();
+                if (result == SUCCESS_EXIT_CODE || retryCount == 0 || tryCount >= retryCount) {
+                    return result;
+                }
+
+                if (!needRetry(c.getLines())) {
+                    return result;
+                }
+
+                log.info("Error pulling the image. Retry after {} sec", retryInterval / 1000);
+                sleep(retryInterval);
+                tryCount++;
+            }
+        } while (!Thread.currentThread().isInterrupted() && tryCount <= retryCount);
+
+        return result;
+    }
+
+    private com.walmartlabs.concord.runtime.v2.runner.DockerProcessBuilder.DockerProcess build(DockerContainerSpec spec) throws IOException {
+        DockerProcessBuilder b = DockerProcessBuilder.from(UUID.randomUUID(), spec);
+
+        b.env(createEffectiveEnv(spec.env(), false));
+        // add the default volume - mount the process' workDir as /workspace
+        b.volume(workingDirectory.toString(), WORKSPACE_TARGET_DIR);
+        // add extra volumes from the runner's arguments
+        extraVolumes.forEach(b::volume);
+
+
+        return b.build();
+    }
+
+    private static boolean needRetry(List<String> lines) {
+        for (String l : lines) {
+            for (Pattern p : REGISTRY_ERROR_PATTERNS) {
+                if (p.matcher(l).matches()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void sleep(long t) {
+        try {
+            Thread.sleep(t);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void streamToLog(InputStream in, com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback callback) throws IOException {
+        BufferedReader reader = new TruncBufferedReader(new InputStreamReader(in));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            callback.onLog(line);
+        }
+    }
+
+    private static Map<String, String> createEffectiveEnv(Map<String, String> env, boolean exposeDockerDaemon) {
+        Map<String, String> m = new HashMap<>();
+
+        if (exposeDockerDaemon) {
+            String dockerHost = System.getenv("DOCKER_HOST");
+            if (dockerHost == null) {
+                dockerHost = "unix:///var/run/docker.sock";
+            }
+            m.put("DOCKER_HOST", dockerHost);
+        }
+
+        if (env != null) {
+            m.putAll(env);
+        }
+
+        return m;
+    }
+
+    private static class LogCapture implements com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback {
+
+        private static final int MAX_CAPTURE_LINES = 5;
+
+        private final com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback delegate;
+        private final List<String> lines;
+
+        private LogCapture(com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback delegate) {
+            this.delegate = delegate;
+            this.lines = new ArrayList<>();
+        }
+
+        @Override
+        public void onLog(String line) {
+            if (delegate != null) {
+                delegate.onLog(line);
+            }
+
+            if (lines.size() <= MAX_CAPTURE_LINES) {
+                lines.add(line);
+            }
+        }
+
+        List<String> getLines() {
+            return lines;
+        }
+    }
+}

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerService.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/docker/DockerService.java
@@ -1,5 +1,25 @@
 package com.walmartlabs.concord.plugins.terraform.docker;
 
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
 import com.walmartlabs.concord.common.TruncBufferedReader;
 import com.walmartlabs.concord.runtime.v2.runner.DockerProcessBuilder;
 import com.walmartlabs.concord.runtime.v2.sdk.DockerContainerSpec;

--- a/tasks/terraform/src/test/terraform/main.tf
+++ b/tasks/terraform/src/test/terraform/main.tf
@@ -1,5 +1,16 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
 provider "aws" {
-  profile    = "default"
   region     = "us-west-2"
 }
 

--- a/tasks/terraform/src/test/terraform/minimal_aws/main.tf
+++ b/tasks/terraform/src/test/terraform/minimal_aws/main.tf
@@ -1,0 +1,46 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region     = "us-west-2"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+resource "aws_key_pair" "deployer" {
+  key_name   = "concord-TF-ITs-key"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDOaV1IVyqzYbUXc6RAgVbVxrbNGMKEsLtLXW82FOBUI4x6+bBJVKNqa/c5cntFOQgRm2bs6CfQPmLJFAOlA1gbRXiOrfatX4WYt6p0Z54BqMCaXZ09zqLcInUPmP8eSTmxqKrefJQAsLqJi46knKxdnPqFxAqbfwed2THu3KokUmWoDceZFEuLb/gXkf6uXinFSV1Gp27ulzNFZpxxDUG9357kmJro0nXAObaOCpCCfb3gG2T/TXGaKtCk7tLIS+iSEzYxLWkmTnVciB9qOIRNrw4TmhEUrrcOz8W0e/WB/BtS4Y56y3cCcibx8WPbWMYSRCmOZPLWbY/x13nA92R9pW+j5dmcWjqsYypnZaQMSQumIUl2/TLOCF0/Fphlj8/G0ZMxIjYXEk5g3ZorTvUR1+TJ7Cbrwk4NIROFbpHVm60w+svnqDgNv+cRDDSOmhB5SDOjBvqiVAqtlb8lE8km5M3VbRZ+12QBDR3ILwPRcKoqK6HnVa4jiODweoOSXos= test@concord"
+}
+
+
+output "message" {
+  value = "hello!"
+}
+
+variable "name" {}
+variable "time" {}
+
+output "default_vpc_id" {
+  value = data.aws_vpc.default.id
+}
+
+output "name_from_varfile0" {
+  value = var.name
+}
+
+output "time_from_varfile1" {
+  value = var.time
+}

--- a/tasks/terraform/src/test/terraform/minimal_azure/main.tf
+++ b/tasks/terraform/src/test/terraform/minimal_azure/main.tf
@@ -7,15 +7,18 @@ variable "time" {}
 
 terraform {
   required_providers {
-    azurerm = "=2.20.0"
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "3.17.0"
+    }
   }
 }
 
 provider "azurerm" {
-  client_id = "${var.client_id}"
-  client_secret = "${var.client_secret}"
-  subscription_id = "${var.subscription_id}"
-  tenant_id = "${var.tenant_id}"
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
 
   features {}
 }
@@ -32,9 +35,9 @@ resource "azurerm_resource_group" "mygroup" {
 
 output "resource_group_info" {
   value = {
-    name = azurerm_resource_group.mygroup.name,
-    id = azurerm_resource_group.mygroup.id,
-    location = azurerm_resource_group.mygroup.location
+    name      = azurerm_resource_group.mygroup.name,
+    id        = azurerm_resource_group.mygroup.id,
+    location  = azurerm_resource_group.mygroup.location
   }
 }
 

--- a/tasks/terraform/src/test/terraform/minimal_azure/main.tf
+++ b/tasks/terraform/src/test/terraform/minimal_azure/main.tf
@@ -1,0 +1,47 @@
+variable "client_id" {}
+variable "client_secret" {}
+variable "subscription_id" {}
+variable "tenant_id" {}
+variable "name" {}
+variable "time" {}
+
+terraform {
+  required_providers {
+    azurerm = "=2.20.0"
+  }
+}
+
+provider "azurerm" {
+  client_id = "${var.client_id}"
+  client_secret = "${var.client_secret}"
+  subscription_id = "${var.subscription_id}"
+  tenant_id = "${var.tenant_id}"
+
+  features {}
+}
+
+resource "azurerm_resource_group" "mygroup" {
+  name     = "concord-tf-test-resources"
+  location = "southcentralus"
+
+  lifecycle {
+    ignore_changes = [ tags ]
+  }
+}
+
+
+output "resource_group_info" {
+  value = {
+    name = azurerm_resource_group.mygroup.name,
+    id = azurerm_resource_group.mygroup.id,
+    location = azurerm_resource_group.mygroup.location
+  }
+}
+
+output "name_from_varfile0" {
+  value = var.name
+}
+
+output "time_from_varfile1" {
+  value = var.time
+}

--- a/tasks/terraform/testPayload.sh
+++ b/tasks/terraform/testPayload.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+if [ -f "${PARAM_FILE}" ]; then
+    echo "Reading settings from ${PARAM_FILE}"
+    source "${PARAM_FILE}" # get required parameters from a file
+fi
+
+
+# see if task jar needs build/rebuild
+doBuild=1
+if [ -f ./target/last_hash.md5 ]; then
+  echo "Checking for ./src modifications"
+  lastHash=$(cat ./target/last_hash.md5)
+  # md5sum all source files, then md5sum the result
+  currentHash=$(find ./src -type f -name "*.java" -exec md5sum {} + | md5sum | awk '{print $1}')
+  if [[ "${lastHash}" == "${currentHash}" ]]; then
+    echo "No src files changed. Skipping build..."
+    doBuild=
+  else
+    echo "${currentHash}" > ./target/last_hash.md5
+  fi
+fi
+
+# build task jar if src files changed
+if [ $doBuild ]; then
+  echo "Building task jar..."
+  # cd to parent and build for build
+  pushd ../..
+  # build the task
+  mvn -pl tasks/terraform -DskipTests=true clean install
+  popd || exit
+  # save md5 of src files to check next time
+  find ./src -type f -name "*.java" -exec md5sum {} + | md5sum | awk '{print $1}' > target/last_hash.md5
+fi
+
+# remove old payload files
+rm -rf target/test && mkdir -p target/test
+
+# copy the test flow
+if [ "${RUNTIME:-}" == "v2" ]; then
+  echo "Using runtime-v2"
+  cp testPayloadV2.yml target/test/concord.yml
+else
+  echo "Using runtime-v1"
+  cp testPayloadV1.yml target/test/concord.yml
+fi
+
+# copy terraform config(s)
+mkdir -p target/test/mydir/nested
+tfFile=${TF_FILE:-src/test/resources/com/walmartlabs/concord/plugins/terraform/it/main.tf}
+cp "${tfFile}" target/test/main.tf
+cp "${tfFile}" target/test/mydir/main.tf
+cp "${tfFile}" target/test/mydir/nested/main.tf
+
+if [ ! -z "${EXTA_VARS_FILE:-}" ]; then
+  echo "copying extra vars file..."
+  echo "${EXTA_VARS_FILE} -> target/test/"$(basename "${EXTA_VARS_FILE}")
+  cp "${EXTA_VARS_FILE}" target/test/
+  cp "${EXTA_VARS_FILE}" target/test/mydir/
+  cp "${EXTA_VARS_FILE}" target/test/mydir/nested/
+fi
+
+# copy the task's JAR...
+mkdir -p target/test/lib/
+cp target/terraform-task-*SNAPSHOT.jar target/test/lib/
+
+# template transitive maven dependencies into a concord project file
+mkdir -p target/test/concord
+echo "configuration:" > target/test/concord/dependencies.concord.yml
+echo "  dependencies:" >> target/test/concord/dependencies.concord.yml
+mvn dependency:tree | grep ':compile' | sed -e 's/^.* [+\\]\- /    - mvn:\/\//' -e 's/:compile$//' >> target/test/concord/dependencies.concord.yml
+
+# enable JVM debugging if parameter given and target server is localhost
+if [ "${DEBUG:-}" == "true" ]; then
+  if [[ "${SERVER_URL}" =~ .*"localhost".*  ]]; then
+    echo "Debug enabled"
+    cat > target/test/_agent.json << EOF
+{
+    "jvmArgs": ["-Xdebug", "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y"]
+}
+EOF
+  else
+    echo "Debug not allowed on non-localhost servers"
+  fi
+fi
+
+# create payload archive
+pushd target/test > /dev/null && zip -r payload.zip ./* > /dev/null && popd > /dev/null || exit
+
+# start concord process with payload
+HTTP_CODE=$(curl -sn \
+  -o target/test/out.json \
+  -w '%{http_code}' \
+  ${PROXY:+ -x "${PROXY}"} \
+  ${ENTRY_POINT:+ -F "entryPoint=${ENTRY_POINT}"} \
+  ${ORG:+ -F "org=${ORG}"} \
+  ${PROJECT:+ -F "project=${PROJECT}"} \
+  -F archive=@target/test/payload.zip \
+  ${TF_VERSION:+ -F "arguments.tf_version=${TF_VERSION}"} \
+  ${TF_DOCKER_IMAGE:+ -F "arguments.tf_docker_image=${TF_DOCKER_IMAGE}"} \
+  ${EXTA_VARS_FILE:+ -F "arguments.tf_extra_vars_file="$(basename "${EXTA_VARS_FILE}")} \
+  "${SERVER_URL}/api/v1/process"
+)
+
+ok=$(grep ok target/test/out.json | sed 's/.* : //;s/",\{0,1\}//')
+instanceId=$(grep instanceId target/test/out.json | sed 's/.* "//;s/",\{0,1\}//')
+
+if [[ "${ok}" == "true" ]]
+then
+  echo "Process started successfully."
+  echo "       Logs: ${SERVER_URL}/#/process/${instanceId}/log"
+  echo "Form Wizard: ${SERVER_URL}/#/process/${instanceId}/wizard?fullScreen=true"
+else
+  echo "uh oh. HTTP code : ${HTTP_CODE}"
+  echo "${SERVER_URL}/#/process/${instanceId}/log"
+fi

--- a/tasks/terraform/testPayloadV1.yml
+++ b/tasks/terraform/testPayloadV1.yml
@@ -53,6 +53,12 @@ flows:
         extraVars:
           name: bob
 
+    # make sure things still work after a suspend (e.g. form)
+    - task: sleep
+      in:
+        suspend: true
+        duration: 5 #seconds
+
     - task: terraform
       in:
         dockerImage: "${tf_docker_image}"

--- a/tasks/terraform/testPayloadV1.yml
+++ b/tasks/terraform/testPayloadV1.yml
@@ -1,0 +1,97 @@
+configuration:
+  runtime: "concord-v1"
+  arguments:
+    tf_docker_image: "${null}"
+
+flows:
+  default:
+    # regular run
+    - task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        debug: true
+        action: plan
+
+    # custom $PWD
+    - task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: plan
+        pwd: mydir
+
+    # custom $PWD + [DIR]
+    - task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: plan
+        pwd: mydir
+        dir: nested
+
+  fullTestCustomConfig:
+    - set:
+        tfVersion: "${execution.hasVariable('tf_version') ? tf_version : '1.2.6'}"
+        tfCfg:
+          env: terraform-task-payload-test
+          debug: true
+          toolUrl: "https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"
+          varFiles: "${execution.hasVariable('tf_extra_vars_file') ? [ tf_extra_vars_file ] : [ ]}"
+
+    - log: "Var files: ${tfCfg.varFiles}"
+
+    - task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: plan
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+        varFiles: "${tfCfg.varFiles}"
+        extraEnv:
+          TF_VAR_time: now
+        extraVars:
+          name: bob
+
+    - task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: apply
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        plan: "${result.planPath}"
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+
+    - task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: output
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+        varFiles: "${tfCfg.varFiles}"
+        extraEnv:
+          TF_VAR_time: now
+        extraVars:
+          name: bob
+
+    - log: ${resource.prettyPrintJson(result.data)}
+
+    - task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: destroy
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+        varFiles: "${tfCfg.varFiles}"
+        extraEnv:
+          TF_VAR_time: now
+        extraVars:
+          name: bob

--- a/tasks/terraform/testPayloadV2.yml
+++ b/tasks/terraform/testPayloadV2.yml
@@ -55,6 +55,12 @@ flows:
           name: bob
       out: result
 
+    # make sure things still work after a suspend (e.g. form)
+    - task: sleep
+      in:
+        suspend: true
+        duration: 1 #seconds
+
     - name: "terraform: apply"
       task: terraform
       in:

--- a/tasks/terraform/testPayloadV2.yml
+++ b/tasks/terraform/testPayloadV2.yml
@@ -1,0 +1,106 @@
+configuration:
+  runtime: "concord-v2"
+  arguments:
+    tf_docker_image: "${null}"
+
+flows:
+  default:
+    # regular run
+    - name: "terraform plan: regular run"
+      task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        debug: true
+        action: plan
+
+    - name: "terraform plan: custom pwd"
+      task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: plan
+        pwd: mydir
+
+    - name: "terraform plan: custom pwd + dir"
+      task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: plan
+        pwd: mydir
+        dir: nested
+
+
+  fullTestCustomConfig:
+    - set:
+        tfVersion: "${hasVariable('tf_version') ? tf_version : '1.2.6'}"
+        tfCfg:
+          env: terraform-task-payload-test
+          debug: true
+          toolUrl: "https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"
+          varFiles: "${hasVariable('tf_extra_vars_file') ? [ tf_extra_vars_file ] : [ ]}"
+
+    - name: "terraform: plan"
+      task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: plan
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+        varFiles: "${tfCfg.varFiles}"
+        extraEnv:
+          TF_VAR_time: now
+        extraVars:
+          name: bob
+      out: result
+
+    - name: "terraform: apply"
+      task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: apply
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        plan: "${result.planPath}"
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+      out: result
+
+    - name: "terraform output"
+      task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: output
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+        varFiles: "${tfCfg.varFiles}"
+        extraEnv:
+          TF_VAR_time: now
+        extraVars:
+          name: bob
+      out: result
+
+    - name: "output data"
+      log: ${resource.prettyPrintJson(result.data)}
+
+    - name: "terraform: destroy"
+      task: terraform
+      in:
+        dockerImage: "${tf_docker_image}"
+        action: destroy
+        debug: "${tfCfg.debug}"
+        pwd: mydir
+        backend: concord
+        toolUrl: "${tfCfg.toolUrl}"
+        stateId: "${tfCfg.env}-tf-state"
+        varFiles: "${tfCfg.varFiles}"
+        extraEnv:
+          TF_VAR_time: now
+        extraVars:
+          name: bob
+      out: result


### PR DESCRIPTION
Initial support for executing terraform commands inside a docker container. Helpful for executing with dependencies (e.g. Azure CLI, large custom modules, etc) that are not reasonable to ship in the main Concord Agent container.

* Support for executing terraform in a docker container
* Fix https://github.com/walmartlabs/concord-plugins/issues/88
* Simpler [tasks/terraform/src/test/terraform/minimal_aws/main.tf](https://github.com/walmartlabs/concord-plugins/compare/tf-docker-exec?expand=1#diff-36b1c5d6b00d39ec45aa1be057b9bf66bd85f280fe6a9776083a12879a475382) for AWS testing (so we don't accidentally leave compute laying around after a failed test)
* More tests