### PR TITLE
taurus: use DependencyManager to resolve jmeter and plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <scm.connection>scm:git:https://github.com/walmartlabs/concord-plugins.git</scm.connection>
 
-        <concord.version>1.93.0</concord.version>
+        <concord.version>1.95.0</concord.version>
         <wiremock.version>2.27.2</wiremock.version>
     </properties>
 

--- a/tasks/taurus/README.md
+++ b/tasks/taurus/README.md
@@ -1,0 +1,22 @@
+# Taurus Task
+
+Concord plugin for executing automated tests with Taurus.
+
+## Tests
+
+The included tests requires `bzt` to be available on the host executing the tests. See the
+[docs](https://gettaurus.org/install/Installation/) for installation.
+
+The included tests depend on a local concord server running on the default port (8001). This can be overridden to any
+other HTTP endpoint with a `TAURUS_TEST_API_ENDPOINT` environment variable for testing (be considerate, keep it local!). 
+
+```shell
+$ export TAURUS_TEST_API_ENDPOINT=http://someOtherConcord:8001/api/v1/server/ping
+$ ./mvnw -pl tasks/taurus clean install -DskipTests=false
+
+...
+
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
+```

--- a/tasks/taurus/pom.xml
+++ b/tasks/taurus/pom.xml
@@ -94,6 +94,11 @@
             <version>${concord.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runner-v2</artifactId>
+            <version>${concord.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tasks/taurus/pom.xml
+++ b/tasks/taurus/pom.xml
@@ -12,8 +12,8 @@
     <packaging>takari-jar</packaging>
 
     <properties>
+        <skipTests>true</skipTests>
         <cmdRunnerVersion>2.2</cmdRunnerVersion>
-        <jmeterRepo>https://www.apache.org/dist</jmeterRepo>
         <jmeterVersion>5.5</jmeterVersion>
         <pluginsCasutgVersion>2.9</pluginsCasutgVersion>
         <pluginsMgrVersion>1.3</pluginsMgrVersion>
@@ -79,8 +79,19 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord</groupId>
+            <artifactId>concord-dependency-manager</artifactId>
+            <version>${concord.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -101,70 +112,20 @@
                 <artifactId>sisu-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>wagon-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <executions>
-                    <execution>
-                        <id>download-jmeter</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                            <url>${jmeterRepo}</url>
-                            <fromFile>jmeter/binaries/apache-jmeter-${jmeterVersion}.zip</fromFile>
-                            <toFile>
-                                ${project.build.directory}/classes/com/walmartlabs/concord/plugins/taurus/apache-jmeter.zip
-                            </toFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
                 <executions>
                     <execution>
-                        <id>download-dependencies</id>
-                        <phase>generate-sources</phase>
+                        <id>integration-test</id>
                         <goals>
-                            <goal>copy</goal>
+                            <goal>integration-test</goal>
                         </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>kg.apc</groupId>
-                                    <artifactId>cmdrunner</artifactId>
-                                    <version>${cmdRunnerVersion}</version>
-                                    <destFileName>cmdrunner-${cmdRunnerVersion}.jar</destFileName>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>kg.apc</groupId>
-                                    <artifactId>jmeter-plugins-manager</artifactId>
-                                    <version>${pluginsMgrVersion}</version>
-                                    <destFileName>jmeter-plugins-manager-${pluginsMgrVersion}.jar</destFileName>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>kg.apc</groupId>
-                                    <artifactId>jmeter-plugins-casutg</artifactId>
-                                    <version>${pluginsCasutgVersion}</version>
-                                    <destFileName>jmeter-plugins-casutg-${pluginsCasutgVersion}.jar</destFileName>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>kg.apc</groupId>
-                                    <artifactId>jmeter-plugins-prmctl</artifactId>
-                                    <version>${pluginsPrmctlVersion}</version>
-                                    <destFileName>jmeter-plugins-prmctl-${pluginsPrmctlVersion}.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>
-                                ${project.build.directory}/classes/com/walmartlabs/concord/plugins/taurus/
-                            </outputDirectory>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <skipTests>${skipTests}</skipTests>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/BinaryResolver.java
+++ b/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/BinaryResolver.java
@@ -1,0 +1,41 @@
+package com.walmartlabs.concord.plugins.taurus;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class BinaryResolver {
+
+    private final BinaryDownloader binaryDownloader;
+
+    public BinaryResolver(BinaryDownloader binaryDownloader) {
+        this.binaryDownloader = binaryDownloader;
+    }
+
+    public Path resolve(String url) throws Exception {
+        return binaryDownloader.download(url);
+    }
+
+    public interface BinaryDownloader {
+        Path download(String url) throws IOException;
+    }
+}

--- a/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/Constants.java
+++ b/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/Constants.java
@@ -24,13 +24,13 @@ public final class Constants {
 
     public static final String BINARY_NAME = "bzt";
     public static final String DEFAULT_EXECUTOR = "jmeter";
-    public static final String DEPENDENCY_JMETER = "apache-jmeter.zip";
-    public static final String DEPENDENCY_CMD_RUNNER = "cmdrunner-" + Version.getCmdRunnerVersion() + ".jar";
-    public static final String DEPENDENCY_CASUTG = "jmeter-plugins-casutg-" + Version.getPluginsCasutgVersion() + ".jar";
-    public static final String DEPENDENCY_PLUGINS_MGR = "jmeter-plugins-manager-" + Version.getPluginMgrVersion() + ".jar";
+    public static final String DEFAULT_JMETER_URL = "https://www.apache.org/dist/jmeter/binaries/apache-jmeter-5.5.zip";
+    public static final String DEPENDENCY_CMD_RUNNER = "mvn://kg.apc:cmdrunner:jar:" + Version.getCmdRunnerVersion();
+    public static final String DEPENDENCY_CASUTG = "mvn://kg.apc:jmeter-plugins-casutg:jar:" + Version.getPluginsCasutgVersion();
+    public static final String DEPENDENCY_PLUGINS_MGR = "mvn://kg.apc:jmeter-plugins-manager:jar:" + Version.getPluginMgrVersion();
     public static final String PLUGIN_MANAGER_CMD = "PluginsManagerCMD.sh";
     public static final String DUMMY_PLUGIN_MANAGER_CMD = "DummyPluginsManagerCMD.sh";
-    public static final String DEPENDENCY_PRMCTL = "jmeter-plugins-prmctl-" + Version.getPluginsPrmctlVersion() + ".jar";
+    public static final String DEPENDENCY_PRMCTL = "mvn://kg.apc:jmeter-plugins-prmctl:jar:" + Version.getPluginsPrmctlVersion();
     public static final String JMETER_TMP_DIR = ".bzt/jmeter-taurus";
     public static final String JMETER_PATH = ".bzt/jmeter-taurus/apache-jmeter-" + Version.getJMeterVersion();
     public static final String JMETER_PATH_BIN = JMETER_PATH + "/bin/";

--- a/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/TaskParams.java
+++ b/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/TaskParams.java
@@ -43,6 +43,7 @@ public class TaskParams {
     private static final String ACTION_KEY = "action";
     private static final String DOWNLOAD_PLUGINS = "downloadPlugins";
     private static final String USE_FAKE_HOME_KEY = "useFakeHome";
+    private static final String JMETER_URL_KEY = "jmeterArchiveUrl";
 
     protected final Variables variables;
 
@@ -65,7 +66,9 @@ public class TaskParams {
     public boolean downloadPlugins() {
         return variables.getBoolean(DOWNLOAD_PLUGINS, false);
     }
-
+    public String jmeterArchiveUrl() {
+        return variables.getString(JMETER_URL_KEY, Constants.DEFAULT_JMETER_URL);
+    }
 
     public static class RunParams extends TaskParams {
 
@@ -103,6 +106,7 @@ public class TaskParams {
         public List<Object> configs() {
             return variables.assertList(CONFIGS_KEY);
         }
+
     }
 
     private static Variables merge(Variables variables, Map<String, Object> defaults) {

--- a/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/TaurusDockerService.java
+++ b/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/TaurusDockerService.java
@@ -1,0 +1,142 @@
+package com.walmartlabs.concord.plugins.taurus;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public interface TaurusDockerService {
+    int start(DockerContainerSpec spec,
+              DockerLogCallback outLog,
+              DockerLogCallback errLog) throws Exception;
+
+    class DockerContainerSpec {
+
+        private String image;
+        private List<String> args;
+        private Map<String, String> env;
+        private boolean debug;
+        private boolean forcePull;
+        private Collection<String> extraDockerHosts;
+        private int pullRetryCount;
+        private long pullRetryInterval;
+        private Path pwd;
+
+        public String image() {
+            return image;
+        }
+
+        public DockerContainerSpec image(String image) {
+            this.image = image;
+            return this;
+        }
+
+        public List<String> args() {
+            return args;
+        }
+
+        public DockerContainerSpec args(List<String> args) {
+            this.args = args;
+            return this;
+        }
+
+        public Map<String, String> env() {
+            return this.env;
+        }
+
+        public DockerContainerSpec env(Map<String, String> env) {
+            this.env = env;
+            return this;
+        }
+
+        public boolean debug() {
+            return this.debug;
+        }
+
+        public DockerContainerSpec debug(boolean debug) {
+            this.debug = debug;
+            return this;
+        }
+
+        public boolean forcePull() {
+            return this.forcePull;
+        }
+
+        public DockerContainerSpec forcePull(boolean forcePull) {
+            this.forcePull = forcePull;
+            return this;
+        }
+
+        public Collection<String> extraDockerHosts() {
+            return this.extraDockerHosts;
+        }
+
+        public DockerContainerSpec extraDockerHosts(Collection<String> extraDockerHosts) {
+            this.extraDockerHosts = extraDockerHosts;
+            return this;
+        }
+
+        public int pullRetryCount() {
+            return this.pullRetryCount;
+        }
+
+        public DockerContainerSpec pullRetryCount(int pullRetryCount) {
+            this.pullRetryCount = pullRetryCount;
+            return this;
+        }
+
+        public long pullRetryInterval() {
+            return this.pullRetryInterval;
+        }
+
+        public DockerContainerSpec pullRetryInterval(long pullRetryInterval) {
+            this.pullRetryInterval = pullRetryInterval;
+            return this;
+        }
+
+        public Path pwd() {
+            return this.pwd;
+        }
+
+        public DockerContainerSpec pwd(Path pwd) {
+            this.pwd = pwd;
+            return this;
+        }
+    }
+
+    class DockerLogCallback {
+        final StringBuilder sb;
+        final String logPrefix;
+        final boolean silent;
+
+        DockerLogCallback(String logPrefix, boolean silent) {
+            this.logPrefix = logPrefix;
+            this.silent = silent;
+            sb = new StringBuilder();
+        }
+
+        public void onLog(String line) {
+            if (!silent) {
+                log(logPrefix, line);
+            }
+
+            sb.append(removeAnsiColors(line))
+                    .append(System.lineSeparator());
+        }
+
+        private static String removeAnsiColors(String s) {
+            return s.replaceAll("\u001B\\[[;\\d]*m", "");
+        }
+
+        private static void log(String prefix, String s) {
+            System.out.print("\u001b[34mtaurus\u001b[0m " + prefix + ": ");
+            System.out.print(s);
+            System.out.println();
+        }
+
+        public String fullLog() {
+            return sb.toString();
+        }
+    }
+
+}

--- a/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskCommon.java
+++ b/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskCommon.java
@@ -51,11 +51,11 @@ public class TaurusTaskCommon {
         this.workDir = workDir;
     }
 
-    public Taurus.Result execute(TaskParams in) throws Exception {
+    public Taurus.Result execute(TaskParams in, BinaryResolver binaryResolver) throws Exception {
 
         // we're going to use a fake JMeter's PluginsManagerCMD script unless users specifically
         // ask us to download JMX plugins
-        Taurus taurus = new Taurus(workDir, in.useFakeHome(), !in.downloadPlugins());
+        Taurus taurus = new Taurus(workDir, in.useFakeHome(), !in.downloadPlugins(), in.jmeterArchiveUrl(), binaryResolver);
 
         Action action = in.action();
         switch (action) {
@@ -93,7 +93,7 @@ public class TaurusTaskCommon {
                 throw new RuntimeException("Taurus execution finished with code " + r.getCode() + ": " + r.getStderr());
             }
 
-            log.info("No problems occured during taurus execution. Completed with code: " + r.getCode());
+            log.info("No problems occurred during taurus execution. Completed with code: " + r.getCode());
             return r;
         } catch (Exception e) {
             if (in.ignoreErrors()) {

--- a/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/Utils.java
+++ b/tasks/taurus/src/main/java/com/walmartlabs/concord/plugins/taurus/Utils.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.plugins.taurus;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public final class Utils {
 
@@ -39,6 +40,10 @@ public final class Utils {
 
         Files.createDirectories(p);
         return p;
+    }
+
+    public static Path toContainerPath(Path processWorkDir, Path p) {
+        return Paths.get("/workspace").resolve(processWorkDir.relativize(p));
     }
 
     private Utils() {

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/AbstractIT.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/AbstractIT.java
@@ -20,6 +20,7 @@ package com.walmartlabs.concord.plugins.taurus;
  * =====
  */
 
+import com.walmartlabs.concord.plugins.taurus.docker.DockerService;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
@@ -32,10 +33,12 @@ import java.util.*;
 public abstract class AbstractIT {
 
     private Path workDir;
+    private DockerService dockerService;
 
     @BeforeEach
     public void setup() throws IOException {
         this.workDir = Files.createTempDirectory("test");
+        this.dockerService = new DockerService(workDir, Collections.emptyList());
     }
 
     protected static Optional<String> envToOptional(String varName) {
@@ -50,6 +53,10 @@ public abstract class AbstractIT {
 
     protected Path workDir() {
         return this.workDir;
+    }
+
+    protected DockerService dockerService() {
+        return this.dockerService;
     }
 
     protected void prepareScenario() throws IOException, URISyntaxException {

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskIT.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskIT.java
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.Test;
 public class TaurusTaskIT extends AbstractIT {
 
     @Test
-    public void test() throws Exception {
+    public void testV1() throws Exception {
         prepareScenario();
 
         Context ctx = new MockContext(getArgs());
 
         TestDependencyManager testDM = new TestDependencyManager("taurus");
-        TaurusTask t = new TaurusTask(testDM::resolve);
+        TaurusTask t = new TaurusTask(testDM::resolve, dockerService());
 
         t.execute(ctx);
     }

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskIT.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskIT.java
@@ -1,0 +1,40 @@
+package com.walmartlabs.concord.plugins.taurus;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2019 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.sdk.Context;
+import com.walmartlabs.concord.sdk.MockContext;
+import org.junit.jupiter.api.Test;
+
+public class TaurusTaskIT extends AbstractIT {
+
+    @Test
+    public void test() throws Exception {
+        prepareScenario();
+
+        Context ctx = new MockContext(getArgs());
+
+        TestDependencyManager testDM = new TestDependencyManager("taurus");
+        TaurusTask t = new TaurusTask(testDM::resolve);
+
+        t.execute(ctx);
+    }
+}

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskV2IT.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskV2IT.java
@@ -41,7 +41,7 @@ public class TaurusTaskV2IT extends AbstractIT {
         Mockito.when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.emptyMap()));
 
         TestDependencyManager testDM = new TestDependencyManager("taurus");
-        TaurusTaskV2 t = new TaurusTaskV2(ctx, testDM::resolve);
+        TaurusTaskV2 t = new TaurusTaskV2(ctx, testDM::resolve, dockerService());
 
         t.execute(new MapBackedVariables(getArgs()));
     }

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskV2IT.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TaurusTaskV2IT.java
@@ -1,0 +1,48 @@
+package com.walmartlabs.concord.plugins.taurus;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2019 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.plugins.taurus.v2.TaurusTaskV2;
+import com.walmartlabs.concord.runtime.v2.sdk.Context;
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class TaurusTaskV2IT extends AbstractIT {
+
+    @Test
+    public void testV2() throws Exception {
+        prepareScenario();
+
+        Context ctx = Mockito.mock(Context.class);
+
+        Mockito.when(ctx.workingDirectory()).thenReturn(workDir());
+        // TODO test more inputs as default variables
+        Mockito.when(ctx.defaultVariables()).thenReturn(new MapBackedVariables(Collections.emptyMap()));
+
+        TestDependencyManager testDM = new TestDependencyManager("taurus");
+        TaurusTaskV2 t = new TaurusTaskV2(ctx, testDM::resolve);
+
+        t.execute(new MapBackedVariables(getArgs()));
+    }
+}

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TestDependencyManager.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/TestDependencyManager.java
@@ -1,0 +1,73 @@
+package com.walmartlabs.concord.plugins.taurus;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.dependencymanager.DependencyEntity;
+import com.walmartlabs.concord.dependencymanager.DependencyManager;
+import com.walmartlabs.concord.dependencymanager.DependencyManagerConfiguration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+public class TestDependencyManager {
+
+    private final DependencyManager dm;
+
+    public TestDependencyManager(String tool) throws IOException {
+        Path toolDir = Paths.get(System.getProperty("user.home"), ".m2/tools/", tool);
+        assertToolDir(toolDir);
+
+        this.dm = new DependencyManager(DependencyManagerConfiguration.of(toolDir));
+    }
+
+    private static void assertToolDir(Path toolDir) {
+        if (Files.exists(toolDir)) {
+            return;
+        }
+
+        Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxr-x---");
+
+        if (Files.exists(toolDir)) {
+            return;
+        }
+
+        try {
+            if (!Files.exists(Files.createDirectories(toolDir, PosixFilePermissions.asFileAttribute(perms)))) {
+                throw new Exception("Failed to crate tool cache directory: " + toolDir);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to create cache directory for terraform executable.");
+        }
+    }
+
+    public Path resolve(URI dependency) throws IOException {
+
+        DependencyEntity de = dm.resolveSingle(dependency);
+
+        return de.getPath();
+    }
+}

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/docker/DockerContainerSpecV1Compat.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/docker/DockerContainerSpecV1Compat.java
@@ -1,0 +1,102 @@
+package com.walmartlabs.concord.plugins.taurus.docker;
+
+import com.walmartlabs.concord.runtime.v2.sdk.DockerContainerSpec;
+
+import java.util.List;
+import java.util.Map;
+
+public class DockerContainerSpecV1Compat implements DockerContainerSpec {
+
+    com.walmartlabs.concord.sdk.DockerContainerSpec specV1;
+
+    public DockerContainerSpecV1Compat(com.walmartlabs.concord.sdk.DockerContainerSpec specV1) {
+        this.specV1 = specV1;
+    }
+
+    public String image() {
+        return specV1.image();
+    }
+
+    public String name() {
+        return specV1.name();
+    }
+
+    public String user() {
+        return specV1.user();
+    }
+
+    public String workdir() {
+        return specV1.workdir();
+    }
+
+    public String entryPoint() {
+        return specV1.entryPoint();
+    }
+
+    public String cpu() {
+        return specV1.cpu();
+    }
+
+    public String memory() {
+        return specV1.memory();
+    }
+
+    public String stdOutFilePath() {
+        return specV1.stdOutFilePath();
+    }
+
+    public List<String> args() {
+        return specV1.args();
+    }
+
+    public Map<String, String> env() {
+        return specV1.env();
+    }
+
+    public String envFile() {
+        return specV1.envFile();
+    }
+
+    public Map<String, String> labels() {
+        return specV1.labels();
+    }
+
+    @Override
+    public Options options() {
+
+        if (specV1.options() == null) {
+            return null;
+        }
+
+        // Convert runtime-v1 docker options object to runtime-v2
+        com.walmartlabs.concord.sdk.DockerContainerSpec.Options o = specV1.options();
+
+        if (o == null || o.hosts() == null) {
+            return null;
+        }
+
+        return Options.builder()
+                .hosts(o.hosts())
+                .build();
+    }
+
+    public int pullRetryCount() {
+        return specV1.pullRetryCount();
+    }
+
+    public long pullRetryInterval() {
+        return specV1.pullRetryInterval();
+    }
+
+    public boolean debug() {
+        return specV1.debug();
+    }
+
+    public boolean forcePull() {
+        return specV1.forcePull();
+    }
+
+    public boolean redirectErrorStream() {
+        return specV1.redirectErrorStream();
+    }
+}

--- a/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/docker/DockerService.java
+++ b/tasks/taurus/src/test/java/com/walmartlabs/concord/plugins/taurus/docker/DockerService.java
@@ -1,0 +1,172 @@
+package com.walmartlabs.concord.plugins.taurus.docker;
+
+import com.walmartlabs.concord.common.TruncBufferedReader;
+import com.walmartlabs.concord.runtime.v2.runner.DockerProcessBuilder;
+import com.walmartlabs.concord.runtime.v2.sdk.DockerContainerSpec;
+import com.walmartlabs.concord.sdk.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class DockerService implements com.walmartlabs.concord.sdk.DockerService, com.walmartlabs.concord.runtime.v2.sdk.DockerService {
+    private static final Logger log = LoggerFactory.getLogger(DockerService.class);
+
+    private static final int SUCCESS_EXIT_CODE = 0;
+    private static final String WORKSPACE_TARGET_DIR = "/workspace";
+
+    private final Path workingDirectory;
+    private final List<String> extraVolumes;
+
+    private static final Pattern[] REGISTRY_ERROR_PATTERNS = {
+            Pattern.compile("Error response from daemon.*received unexpected HTTP status: 5.*"),
+            Pattern.compile("Error response from daemon.*Get.*connection refused.*"),
+            Pattern.compile("Error response from daemon.*Client.Timeout exceeded.*")
+    };
+
+    public DockerService(Path workingDirectory, List<String> extraVolumes) {
+        this.workingDirectory = workingDirectory;
+        this.extraVolumes = extraVolumes;
+    }
+
+    @Override
+    public Process start(Context ctx, com.walmartlabs.concord.sdk.DockerContainerSpec spec) throws IOException {
+        throw new RuntimeException("deprecated. not implemented.");
+    }
+
+    @Override
+    public int start(Context ctx, com.walmartlabs.concord.sdk.DockerContainerSpec specV1,
+                     com.walmartlabs.concord.sdk.DockerService.LogCallback outCallback,
+                     com.walmartlabs.concord.sdk.DockerService.LogCallback errCallback)
+            throws IOException, InterruptedException {
+        return start(new DockerContainerSpecV1Compat(specV1), outCallback::onLog, errCallback::onLog);
+    }
+
+    @Override
+    public int start(DockerContainerSpec spec,
+                     com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback outCallback,
+                     com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback errCallback) throws IOException, InterruptedException {
+        int tryCount = 0;
+        int result;
+        int retryCount = Math.max(spec.pullRetryCount(), 0);
+        long retryInterval = spec.pullRetryInterval();
+
+        do {
+            try (DockerProcessBuilder.DockerProcess dp = build(spec)) {
+                Process p = dp.start();
+
+                LogCapture c = new LogCapture(outCallback);
+                streamToLog(p.getInputStream(), c);
+                if (errCallback != null) {
+                    streamToLog(p.getErrorStream(), errCallback);
+                }
+
+                result = p.waitFor();
+                if (result == SUCCESS_EXIT_CODE || retryCount == 0 || tryCount >= retryCount) {
+                    return result;
+                }
+
+                if (!needRetry(c.getLines())) {
+                    return result;
+                }
+
+                log.info("Error pulling the image. Retry after {} sec", retryInterval / 1000);
+                sleep(retryInterval);
+                tryCount++;
+            }
+        } while (!Thread.currentThread().isInterrupted() && tryCount <= retryCount);
+
+        return result;
+    }
+
+    private DockerProcessBuilder.DockerProcess build(DockerContainerSpec spec) throws IOException {
+        DockerProcessBuilder b = DockerProcessBuilder.from(UUID.randomUUID(), spec);
+
+        b.env(createEffectiveEnv(spec.env(), false));
+        // add the default volume - mount the process' workDir as /workspace
+        b.volume(workingDirectory.toString(), WORKSPACE_TARGET_DIR);
+        // add extra volumes from the runner's arguments
+        extraVolumes.forEach(b::volume);
+
+        return b.build();
+    }
+
+    private static boolean needRetry(List<String> lines) {
+        for (String l : lines) {
+            for (Pattern p : REGISTRY_ERROR_PATTERNS) {
+                if (p.matcher(l).matches()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void sleep(long t) {
+        try {
+            Thread.sleep(t);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void streamToLog(InputStream in, com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback callback) throws IOException {
+        BufferedReader reader = new TruncBufferedReader(new InputStreamReader(in));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            callback.onLog(line);
+        }
+    }
+
+    private static Map<String, String> createEffectiveEnv(Map<String, String> env, boolean exposeDockerDaemon) {
+        Map<String, String> m = new HashMap<>();
+
+        if (exposeDockerDaemon) {
+            String dockerHost = System.getenv("DOCKER_HOST");
+            if (dockerHost == null) {
+                dockerHost = "unix:///var/run/docker.sock";
+            }
+            m.put("DOCKER_HOST", dockerHost);
+        }
+
+        if (env != null) {
+            m.putAll(env);
+        }
+
+        return m;
+    }
+
+    private static class LogCapture implements com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback {
+
+        private static final int MAX_CAPTURE_LINES = 5;
+
+        private final com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback delegate;
+        private final List<String> lines;
+
+        private LogCapture(com.walmartlabs.concord.runtime.v2.sdk.DockerService.LogCallback delegate) {
+            this.delegate = delegate;
+            this.lines = new ArrayList<>();
+        }
+
+        @Override
+        public void onLog(String line) {
+            if (delegate != null) {
+                delegate.onLog(line);
+            }
+
+            if (lines.size() <= MAX_CAPTURE_LINES) {
+                lines.add(line);
+            }
+        }
+
+        List<String> getLines() {
+            return lines;
+        }
+    }
+}

--- a/tasks/taurus/src/test/resources/com/walmartlabs/concord/plugins/taurus/test.yml
+++ b/tasks/taurus/src/test/resources/com/walmartlabs/concord/plugins/taurus/test.yml
@@ -7,4 +7,4 @@ execution:
 scenarios:
   quick-test:
     requests:
-      - "http://localhost:8001/${endpoint}"
+      - "${apiToTest}"


### PR DESCRIPTION
Stop shipping huge binaries in the plugin, use DependencyManager instead. Adds option to pull a different jmeter zip with `jmeterArchiveUrl` task parameter.

```yaml
- task: taurus
  in:
    jmeterArchiveUrl: 'https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-5.2.zip'
    # ...
```