### PR TITLE
akeyless: support direct usage of access token

### DIFF
--- a/tasks/akeyless/pom.xml
+++ b/tasks/akeyless/pom.xml
@@ -166,6 +166,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <version>5.4.0</version>

--- a/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/SecretCache.java
+++ b/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/SecretCache.java
@@ -23,6 +23,6 @@ package com.walmartlabs.concord.plugins.akeyless.model;
 import java.util.function.Supplier;
 
 public interface SecretCache {
-    String get(String key, Supplier<String> lookup);
-    void put(String key, String value);
+    String get(String org, String name, Supplier<String> lookup);
+    void put(String org, String name, String value);
 }

--- a/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/SecretCacheImpl.java
+++ b/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/SecretCacheImpl.java
@@ -60,17 +60,24 @@ public class SecretCacheImpl implements SecretCache {
     }
 
     @Override
-    public String get(String key, Supplier<String> lookup) {
-        String hash = Util.hash(key + salt);
+    public String get(String org, String name, Supplier<String> lookup) {
+        final String cacheKey = buildKey(org, name, salt);
+        final String hash = Util.hash(cacheKey);
 
         return data.computeIfAbsent(hash, k -> {
-            Util.debug(debug, log, "secret cache miss");
+            Util.debug(debug, log, String.format("secret cache miss: %s/%s", org, name));
             return lookup.get();
         });
     }
 
     @Override
-    public void put(String key, String value) {
-        data.put(Util.hash(key + salt), value);
+    public void put(String org, String name, String value) {
+        final String cacheKey = buildKey(org, name, salt);
+
+        data.put(Util.hash(cacheKey), value);
+    }
+
+    private static String buildKey(String org, String name, String salt) {
+        return String.format("%s/%s/%s", org, salt, name);
     }
 }

--- a/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/SecretCacheNoop.java
+++ b/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/SecretCacheNoop.java
@@ -31,12 +31,12 @@ public class SecretCacheNoop implements SecretCache {
     }
 
     @Override
-    public String get(String key, Supplier<String> lookup) {
+    public String get(String org, String name, Supplier<String> lookup) {
         return lookup.get();
     }
 
     @Override
-    public void put(String key, String value) {
+    public void put(String org, String name, String value) {
         // no cache in noop
     }
 }

--- a/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/TaskParams.java
+++ b/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/TaskParams.java
@@ -78,6 +78,7 @@ public interface TaskParams {
     String sessionId();
     String txId();
     Auth auth();
+    String accessToken();
 
     interface GetSecretParams extends TaskParams {
         String path();
@@ -104,7 +105,6 @@ public interface TaskParams {
         String path();
         String value();
         String protectionKey();
-
         Boolean multiline();
 
         @Value.Default
@@ -114,7 +114,6 @@ public interface TaskParams {
     }
 
     interface DeleteItemParams extends TaskParams {
-
         String path();
         Integer version();
         boolean deleteImmediately();
@@ -122,6 +121,7 @@ public interface TaskParams {
     }
 
     enum Action {
+        AUTH,
         CREATESECRET,
         DELETEITEM,
         GETSECRET,

--- a/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/TaskParamsImpl.java
+++ b/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/TaskParamsImpl.java
@@ -165,7 +165,7 @@ public class TaskParamsImpl implements TaskParams {
             }
 
             if (!(value instanceof String)) {
-                throw new IllegalArgumentException("Non-string value used for secret definition");
+                throw new IllegalArgumentException("Non-string value used for key '" + key + "' in secret definition");
             }
         });
 
@@ -176,8 +176,9 @@ public class TaskParamsImpl implements TaskParams {
         final String o = secretInfo.get("org");
         final String n = secretInfo.get("name");
         final String p = secretInfo.getOrDefault("password", null);
+        final String cacheKey = String.format("%s/%s", o, n);
 
-        return secretCache.get(o + n, () -> {
+        return secretCache.get(cacheKey, () -> {
             try {
                 return secretExporter.exportAsString(o, n, p);
             } catch (Exception e) {

--- a/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/TaskParamsImpl.java
+++ b/tasks/akeyless/src/main/java/com/walmartlabs/concord/plugins/akeyless/model/TaskParamsImpl.java
@@ -176,9 +176,8 @@ public class TaskParamsImpl implements TaskParams {
         final String o = secretInfo.get("org");
         final String n = secretInfo.get("name");
         final String p = secretInfo.getOrDefault("password", null);
-        final String cacheKey = String.format("%s/%s", o, n);
 
-        return secretCache.get(cacheKey, () -> {
+        return secretCache.get(o, n, () -> {
             try {
                 return secretExporter.exportAsString(o, n, p);
             } catch (Exception e) {

--- a/tasks/akeyless/testPayloadV1.yml
+++ b/tasks/akeyless/testPayloadV1.yml
@@ -18,8 +18,8 @@ flows:
     - task: akeyless
       in:
         action: auth
-    - log: "result: ${resource.prettyPrintJson(result)}"
-    - "${akeylessParams.put('accessToken', result.accessToken)}"
+      out:
+        authResult: "${result}"
 
 
     # Create two secrets
@@ -37,6 +37,10 @@ flows:
         value: "value2"
         description: "Description for secret 2"
         multiline: false
+
+
+    # Update default params with access token
+    - "${akeylessParams.put('accessToken', authResult.accessToken)}"
 
 
     # Get and validate one secret

--- a/tasks/akeyless/testPayloadV1.yml
+++ b/tasks/akeyless/testPayloadV1.yml
@@ -14,6 +14,14 @@ configuration:
 
 flows:
   default:
+    # Get an API access token
+    - task: akeyless
+      in:
+        action: auth
+    - log: "result: ${resource.prettyPrintJson(result)}"
+    - "${akeylessParams.put('accessToken', result.accessToken)}"
+
+
     # Create two secrets
     - task: akeyless
       in:
@@ -29,6 +37,7 @@ flows:
         value: "value2"
         description: "Description for secret 2"
         multiline: false
+
 
     # Get and validate one secret
     - task: akeyless

--- a/tasks/akeyless/testPayloadV2.yml
+++ b/tasks/akeyless/testPayloadV2.yml
@@ -22,6 +22,18 @@ flows:
         - log: "result5: ${akeyless.getSecret('/second-secret')}"
 
   default:
+    # Get an API access token
+    - name: "Get API access token"
+      task: akeyless
+      in:
+        action: auth
+      out: authResult
+    - if: "${!authResult.ok}"
+      then:
+        - throw: "Failed to get access token: ${authResult.error}"
+    - "${akeylessParams.put('accessToken', authResult.data.accessToken)}"
+
+
     # Create two secrets
     - name: "Create first secret"
       task: akeyless

--- a/tasks/akeyless/testPayloadV2.yml
+++ b/tasks/akeyless/testPayloadV2.yml
@@ -31,7 +31,6 @@ flows:
     - if: "${!authResult.ok}"
       then:
         - throw: "Failed to get access token: ${authResult.error}"
-    - "${akeylessParams.put('accessToken', authResult.data.accessToken)}"
 
 
     # Create two secrets
@@ -51,6 +50,10 @@ flows:
         value: "value2"
         description: "Description for secret 2"
         multiline: false
+
+
+    - name: "Update default params with access token"
+      expr: "${akeylessParams.put('accessToken', authResult.data.accessToken)}"
 
 
     # Get and validate one secret

--- a/tasks/akeyless/testV2.yml
+++ b/tasks/akeyless/testV2.yml
@@ -1,7 +1,7 @@
 configuration:
   runtime: concord-v2
   dependencies:
-    - mvn://com.walmartlabs.concord.plugins:akeyless-task:1.41.1-SNAPSHOT
+    - mvn://com.walmartlabs.concord.plugins:akeyless-task:1.42.1-SNAPSHOT
   arguments:
     akeylessParams:
       apiBasePath: 'https://api.akeyless.io'
@@ -24,6 +24,18 @@ flows:
         - log: "result5: ${akeyless.getSecret('/second-secret')}"
 
   default:
+    # Get an API access token
+    - name: "Get API access token"
+      task: akeyless
+      in:
+        action: auth
+      out: authResult
+    - if: "${!authResult.ok}"
+      then:
+        - throw: "Failed to get access token: ${authResult.error}"
+    - "${akeylessParams.put('accessToken', authResult.data.accessToken)}"
+
+
     # Create two secrets
     - name: "Create first secret"
       task: akeyless


### PR DESCRIPTION
New action `auth` can be used to obtain an access token.

New parameter `accessToken` can be used to directly provide the access token for calls. Otherwise, the task first generates one from the `auth` param and then uses it for the subsequent API call.