### PR TITLE
s3: exclude unnecessary transitive dependencies

### DIFF
--- a/tasks/s3/pom.xml
+++ b/tasks/s3/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <awssdk.version>1.12.261</awssdk.version>
+        <s3_mock.image.version>latest</s3_mock.image.version>
     </properties>
 
     <dependencies>
@@ -47,6 +48,12 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>${awssdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -76,6 +83,24 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.17.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.testing</groupId>
+            <artifactId>s3mock-testcontainers</artifactId>
+            <version>2.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -83,6 +108,16 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <!-- override with property option -Ds3_mock.image.version=<another_version> -->
+                        <S3_MOCK_IMAGE_VERSION>${s3_mock.image.version}</S3_MOCK_IMAGE_VERSION>
+                    </environmentVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tasks/s3/src/test/java/com/walmartlabs/concord/plugins/s3/S3TaskV2Test.java
+++ b/tasks/s3/src/test/java/com/walmartlabs/concord/plugins/s3/S3TaskV2Test.java
@@ -1,0 +1,100 @@
+package com.walmartlabs.concord.plugins.s3;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2022 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import com.walmartlabs.concord.plugins.s3.v2.S3TaskV2;
+import com.walmartlabs.concord.runtime.v2.sdk.Context;
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.walmartlabs.concord.plugins.s3.TaskParams.ACTION_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@Testcontainers
+class S3TaskV2Test {
+    private static final String TEST_BUCKET = "my-bucket";
+
+    // Container will be started before each test method and stopped after
+    @Container
+    private final S3MockContainer s3Mock =
+            new S3MockContainer(System.getenv("S3_MOCK_IMAGE_VERSION"))
+                    .withInitialBuckets(TEST_BUCKET);
+
+    @Test
+    void localMockTestV2() throws Exception {
+        String data = "Hello!";
+
+        Path p = Files.createTempFile("test", ".txt");
+        Files.write(p, data.getBytes());
+
+        Map<String, Object> auth = new HashMap<>();
+        auth.put("accessKey", "my-access-key");
+        auth.put("secretKey", "my-secret-key");
+
+        Map<String, Object> args = new HashMap<>();
+        args.put(TaskParams.PutObjectParams.BUCKET_NAME_KEY, TEST_BUCKET);
+        args.put(TaskParams.PutObjectParams.OBJECT_KEY, "xyz");
+        args.put(TaskParams.PutObjectParams.SRC_KEY, p.getFileName().toString());
+        args.put(TaskParams.PutObjectParams.ENDPOINT_KEY, s3Mock.getHttpEndpoint());
+        args.put(TaskParams.PutObjectParams.REGION_KEY, "us-west-2");
+        args.put(TaskParams.PutObjectParams.PATH_STYLE_ACCESS_KEY, true);
+        args.put(TaskParams.PutObjectParams.AUTH_KEY, Collections.singletonMap("basic", auth));
+
+        Context context = Mockito.mock(Context.class);
+        
+        when(context.variables()).thenReturn(new MapBackedVariables(Collections.emptyMap()));
+        when(context.defaultVariables()).thenReturn(new MapBackedVariables(Collections.emptyMap()));
+        when(context.workingDirectory()).thenReturn(p.getParent().toAbsolutePath());
+
+        // --- put object
+
+        args.put(ACTION_KEY, TaskParams.Action.PUTOBJECT.name());
+        S3TaskV2 t = new S3TaskV2(context);
+
+        TaskResult.SimpleResult result = (TaskResult.SimpleResult) t.execute(new MapBackedVariables(args));
+
+        assertTrue(result.ok());
+
+        // --- get object
+
+        args.put(Constants.ACTION_KEY, TaskParams.Action.GETOBJECT.name());
+        result = (TaskResult.SimpleResult) t.execute(new MapBackedVariables(args));
+
+        assertTrue(result.ok());
+
+        String storedObject = (String) result.values().get("path");
+        String s = new String(Files.readAllBytes(p.getParent().resolve(storedObject)));
+        assertEquals(data, s);
+    }
+}

--- a/tasks/s3/src/test/resources/logback-test.xml
+++ b/tasks/s3/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%-5level] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Turning down the apache http client logging -->
+    <logger name="org.apache.http" level="WARN"/>
+    <logger name="org.apache" level="ERROR"/>
+    <logger name="com.walmartlabs.concord" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
The transitive dependencies of `aws-java-sdk` are numerous and large, which causes process startup time to suffer dramatically when including the `s3` plugin. The plugin doesn't need the transitive dependencies.

- Exclude `aws-java-sdk` transitive deps. Reduces resolved deps from 264M to 5.9M.
- Update/add unit tests leveraging [testcontainers and S3Mock](https://github.com/adobe/S3Mock#start-using-testcontainers).