### PR TITLE
ldap-task: support for dns SRV resource record

### DIFF
--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapConnectionCfg.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapConnectionCfg.java
@@ -29,6 +29,6 @@ public interface LdapConnectionCfg {
     String bindUserDn();
 
     String bindPassword();
-    
+
     Map<String, Object> dnsSrvRr();
 }

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapConnectionCfg.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapConnectionCfg.java
@@ -20,6 +20,8 @@ package com.walmartlabs.concord.plugins.ldap;
  * =====
  */
 
+import java.util.Map;
+
 public interface LdapConnectionCfg {
 
     String ldapAdServer();
@@ -27,4 +29,6 @@ public interface LdapConnectionCfg {
     String bindUserDn();
 
     String bindPassword();
+    
+    Map<String, Object> dnsSrvRr();
 }

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTask.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTask.java
@@ -36,13 +36,13 @@ public class LdapTask implements Task {
     private static final String LDAP_OUT = "out";
     private static final String LDAP_DEFAULT_OUT = "ldapResult";
 
-    @InjectVariable("ldapParams")
+    @InjectVariable(TaskParams.DEFAULT_PARAMS_KEY)
     private Map<String, Object> defaults;
 
     @Override
     public void execute(Context ctx) {
         Map<String, Object> result = new LdapTaskCommon()
-                .execute(TaskParams.of(new ContextVariables(ctx), defaults));
+                .execute(TaskParams.of(new ContextVariables(ctx), defaults, null));
 
         String key = getString(null, ctx, LDAP_OUT, LDAP_DEFAULT_OUT);
 
@@ -50,7 +50,7 @@ public class LdapTask implements Task {
     }
 
     public boolean isMemberOf(@InjectVariable("context") Context ctx, String userDn, String groupDn) {
-        return new LdapTaskCommon().isMemberOf(TaskParams.searchParams(new ContextVariables(ctx), defaults), userDn, groupDn);
+        return new LdapTaskCommon().isMemberOf(TaskParams.searchParams(new ContextVariables(ctx), defaults, null), userDn, groupDn);
     }
 
     private static class ContextVariables implements Variables {

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
@@ -23,19 +23,20 @@ package com.walmartlabs.concord.plugins.ldap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.naming.CommunicationException;
+import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.SearchControls;
-import javax.naming.directory.SearchResult;
+import javax.naming.directory.*;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
 import javax.net.ssl.SSLHandshakeException;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.walmartlabs.concord.plugins.ldap.TaskParams.*;
+import static com.walmartlabs.concord.sdk.MapUtils.assertString;
 
 public class LdapTaskCommon {
 
@@ -210,20 +211,74 @@ public class LdapTaskCommon {
         }
     }
 
-    private LdapContext establishConnection(LdapConnectionCfg cfg) {
+    private LdapContext establishConnection(LdapConnectionCfg cfg) throws NamingException {
+        if (cfg.dnsSrvRr() != null) {
+            Map<String, Object> dnsSrvRr = cfg.dnsSrvRr();
+            String dnsSrvName = assertString(dnsSrvRr, "name");
+            String protocol = assertString(dnsSrvRr, "protocol");
+            String port = assertString(dnsSrvRr, "port");
+
+            List<String> servers = getLdapServers(dnsSrvName, protocol, port);
+            
+            int index = 0;
+            while (index < servers.size()) {
+                try {
+                    log.info("Connecting to... : {}", servers.get(index));
+                    return establishConnection(cfg, servers.get(index));
+                }
+                catch (CommunicationException ce) {
+                    log.warn("Error while establishing connection with ldap AD server: {}", ce.getMessage());
+                }
+                catch (Exception e) {
+                    throw new IllegalArgumentException("Error while establishing connection " + e);
+                }
+            }
+        }
+        
+        if (cfg.ldapAdServer() != null) {
+            return establishConnection(cfg, cfg.ldapAdServer());
+        }
+
+        throw new IllegalArgumentException("Mandatory variable either'" + LDAP_DNS_SRV_RR + "' or '" + LDAP_AD_SERVER + "' is required");
+    }
+    
+
+    private LdapContext establishConnection(LdapConnectionCfg cfg, String ldapServer) throws NamingException {
         Hashtable<String, Object> env = new Hashtable<>();
         env.put(javax.naming.Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-        env.put(javax.naming.Context.PROVIDER_URL, cfg.ldapAdServer());
+        env.put(javax.naming.Context.PROVIDER_URL, ldapServer);
         env.put(javax.naming.Context.SECURITY_AUTHENTICATION, "simple");
         env.put(javax.naming.Context.SECURITY_PRINCIPAL, cfg.bindUserDn());
         env.put(javax.naming.Context.SECURITY_CREDENTIALS, cfg.bindPassword());
         env.put("java.naming.ldap.version", "3");
-
-        try {
-            return new InitialLdapContext(env, null);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Error while establishing connection " + e);
+        
+        return new InitialLdapContext(env, null);
+    }
+    
+    private List<String> getLdapServers(String dnsSrvName, String protocol, String port) throws NamingException {
+        CopyOnWriteArrayList<String> servers = new CopyOnWriteArrayList<>();
+        Hashtable<String, String> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+        env.put(Context.PROVIDER_URL, "dns:");
+        DirContext ctx = new InitialDirContext(env);
+        Attributes srvs = ctx.getAttributes(dnsSrvName, new String[]{"SRV"});
+        NamingEnumeration<? extends Attribute> srv = srvs.getAll();
+        while (srv.hasMore()) {
+            Attribute srvRecords = (Attribute) srv.next();
+            NamingEnumeration<?> srvRecord = srvRecords.getAll();
+            while (srvRecord.hasMore()) {
+                String attr = (String) srvRecord.next();
+                servers.add(protocol + "://" + removeLastCharIfDot(attr.split(" ")[3]) + ":" + port);
+            }
         }
+        return servers;
+    }
+
+    private static String removeLastCharIfDot(String s) {
+        if (s == null || s.length() == 0 || s.charAt(s.length() - 1) != '.') {
+            return s;
+        }
+        return s.substring(0, s.length() - 1);
     }
 
     private static String getAttrValue(SearchResult result, String id) {

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
@@ -233,7 +233,11 @@ public class LdapTaskCommon {
         }
 
         if (cfg.ldapAdServer() != null) {
-            return establishConnection(cfg, cfg.ldapAdServer());
+            try {
+                return establishConnection(cfg, cfg.ldapAdServer());
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Error while establishing connection " + e);
+            }
         }
 
         throw new IllegalArgumentException("Mandatory variable either '" + LDAP_DNS_SRV_RR + "' or '" + LDAP_AD_SERVER + "' is required");

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
@@ -50,7 +50,7 @@ public class LdapTaskCommon {
             case SEARCHBYDN: {
                 log.info("Starting 'SearchByDn' Action");
 
-                SearchByDnParams p = (SearchByDnParams)in;
+                SearchByDnParams p = (SearchByDnParams) in;
                 SearchResult searchResult = searchByDn(p, p.searchBase(), p.dn());
                 return toResult(searchResult);
             }
@@ -70,7 +70,7 @@ public class LdapTaskCommon {
             }
             case ISMEMBEROF: {
                 log.info("Starting 'IsMemberOf' Action");
-                boolean member = isMemberOf((MemberOfParams)in);
+                boolean member = isMemberOf((MemberOfParams) in);
                 Map<String, Object> result = new HashMap<>();
                 result.put("success", true);
                 result.put("result", member);
@@ -197,7 +197,7 @@ public class LdapTaskCommon {
             searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
 
             // create SearchRequest
-            return withRetry(MAX_RETRIES, RETRY_DELAY, () -> establishConnection(cfg).search(searchBase, searchFilter, searchControls));
+            return connection.search(searchBase, searchFilter, searchControls);
         } catch (Exception e) {
             throw new IllegalArgumentException("Error occurred while searching " + e);
         } finally {
@@ -219,29 +219,27 @@ public class LdapTaskCommon {
             String port = assertString(dnsSrvRr, "port");
 
             List<String> servers = getLdapServers(dnsSrvName, protocol, port);
-            
+
             int index = 0;
             while (index < servers.size()) {
                 try {
                     log.info("Connecting to... : {}", servers.get(index));
                     return establishConnection(cfg, servers.get(index));
-                }
-                catch (CommunicationException ce) {
+                } catch (CommunicationException ce) {
                     log.warn("Error while establishing connection with ldap AD server: {}", ce.getMessage());
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     throw new IllegalArgumentException("Error while establishing connection " + e);
                 }
             }
         }
-        
+
         if (cfg.ldapAdServer() != null) {
             return establishConnection(cfg, cfg.ldapAdServer());
         }
 
-        throw new IllegalArgumentException("Mandatory variable either'" + LDAP_DNS_SRV_RR + "' or '" + LDAP_AD_SERVER + "' is required");
+        throw new IllegalArgumentException("Mandatory variable either '" + LDAP_DNS_SRV_RR + "' or '" + LDAP_AD_SERVER + "' is required");
     }
-    
+
 
     private LdapContext establishConnection(LdapConnectionCfg cfg, String ldapServer) throws NamingException {
         Hashtable<String, Object> env = new Hashtable<>();
@@ -251,10 +249,10 @@ public class LdapTaskCommon {
         env.put(javax.naming.Context.SECURITY_PRINCIPAL, cfg.bindUserDn());
         env.put(javax.naming.Context.SECURITY_CREDENTIALS, cfg.bindPassword());
         env.put("java.naming.ldap.version", "3");
-        
+
         return new InitialLdapContext(env, null);
     }
-    
+
     private List<String> getLdapServers(String dnsSrvName, String protocol, String port) throws NamingException {
         CopyOnWriteArrayList<String> servers = new CopyOnWriteArrayList<>();
         Hashtable<String, String> env = new Hashtable<>();

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/LdapTaskCommon.java
@@ -223,10 +223,9 @@ public class LdapTaskCommon {
             int index = 0;
             while (index < servers.size()) {
                 try {
-                    log.info("Connecting to... : {}", servers.get(index));
                     return establishConnection(cfg, servers.get(index));
                 } catch (CommunicationException ce) {
-                    log.warn("Error while establishing connection with ldap AD server: {}", ce.getMessage());
+                    log.warn("Error while establishing connection with ldap AD server: {}, Exception: {}", servers.get(index), ce.getMessage());
                 } catch (Exception e) {
                     throw new IllegalArgumentException("Error while establishing connection " + e);
                 }

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/TaskParams.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/TaskParams.java
@@ -27,8 +27,9 @@ import java.util.*;
 
 public class TaskParams implements LdapSearchParams {
 
-    public static TaskParams of(Variables input, Map<String, Object> defaults) {
-        Variables variables = merge(input, defaults);
+    public static TaskParams of(Variables input, Map<String, Object> defaults, Map<String, Object> policyDefaults) {
+
+        Variables variables = merge(input, defaults, policyDefaults);
 
         Action action = new TaskParams(variables).action();
         switch (action) {
@@ -49,13 +50,14 @@ public class TaskParams implements LdapSearchParams {
         }
     }
 
-    public static LdapSearchParams searchParams(Variables input, Map<String, Object> defaults) {
-        Variables variables = merge(input, defaults);
+    public static LdapSearchParams searchParams(Variables input, Map<String, Object> defaults, Map<String, Object> policyDefaults) {
+        Variables variables = merge(input, defaults, policyDefaults);
         return new TaskParams(variables);
     }
 
     private static final String ACTION_KEY = "action";
 
+    public static final String DEFAULT_PARAMS_KEY = "ldapParams";
     public static final String LDAP_AD_SERVER = "ldapAdServer";
     private static final String LDAP_BIND_USER_DN = "bindUserDn";
     private static final String LDAP_BIND_PASSWORD = "bindPassword";
@@ -81,7 +83,7 @@ public class TaskParams implements LdapSearchParams {
     public String ldapAdServer() {
         return variables.getString(LDAP_AD_SERVER);
     }
-    
+
     @Override
     public Map<String, Object> dnsSrvRr() {
         return variables.getMap(LDAP_DNS_SRV_RR, null);
@@ -96,7 +98,7 @@ public class TaskParams implements LdapSearchParams {
     public String bindPassword() {
         return variables.getString(LDAP_BIND_PASSWORD);
     }
-    
+
     @Override
     public String searchBase() {
         return variables.assertString(LDAP_SEARCH_BASE);
@@ -186,9 +188,10 @@ public class TaskParams implements LdapSearchParams {
         ISMEMBEROF
     }
 
-    private static Variables merge(Variables variables, Map<String, Object> defaults) {
-        Map<String, Object> variablesMap = new HashMap<>(defaults != null ? defaults : Collections.emptyMap());
-        variablesMap.putAll(variables.toMap());
-        return new MapBackedVariables(variablesMap);
+    private static Variables merge(Variables variables, Map<String, Object> defaults, Map<String, Object> policyDefaults) {
+        Map<String, Object> mergedVars = new HashMap<>(policyDefaults != null ? policyDefaults : Collections.emptyMap());
+        mergedVars.putAll(defaults);
+        mergedVars.putAll(variables.toMap());
+        return new MapBackedVariables(mergedVars);
     }
 }

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/TaskParams.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/TaskParams.java
@@ -56,10 +56,11 @@ public class TaskParams implements LdapSearchParams {
 
     private static final String ACTION_KEY = "action";
 
-    private static final String LDAP_AD_SERVER = "ldapAdServer";
+    public static final String LDAP_AD_SERVER = "ldapAdServer";
     private static final String LDAP_BIND_USER_DN = "bindUserDn";
     private static final String LDAP_BIND_PASSWORD = "bindPassword";
     private static final String LDAP_SEARCH_BASE = "searchBase";
+    public static final String LDAP_DNS_SRV_RR = "dnsSrvRr";
 
     protected final Variables variables;
 
@@ -78,7 +79,12 @@ public class TaskParams implements LdapSearchParams {
 
     @Override
     public String ldapAdServer() {
-        return variables.assertString(LDAP_AD_SERVER);
+        return variables.getString(LDAP_AD_SERVER);
+    }
+    
+    @Override
+    public Map<String, Object> dnsSrvRr() {
+        return variables.getMap(LDAP_DNS_SRV_RR, null);
     }
 
     @Override
@@ -90,7 +96,7 @@ public class TaskParams implements LdapSearchParams {
     public String bindPassword() {
         return variables.getString(LDAP_BIND_PASSWORD);
     }
-
+    
     @Override
     public String searchBase() {
         return variables.assertString(LDAP_SEARCH_BASE);

--- a/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/v2/LdapTaskV2.java
+++ b/tasks/ldap/src/main/java/com/walmartlabs/concord/plugins/ldap/v2/LdapTaskV2.java
@@ -29,6 +29,7 @@ import com.walmartlabs.concord.sdk.MapUtils;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @Named("ldap")
@@ -39,20 +40,23 @@ public class LdapTaskV2 implements Task {
 
     private final LdapTaskCommon delegate = new LdapTaskCommon();
 
+    private final Map<String, Object> defaults;
+
     @Inject
     public LdapTaskV2(Context context) {
         this.context = context;
+        this.defaults = new HashMap<>(context.variables().getMap(TaskParams.DEFAULT_PARAMS_KEY, Collections.emptyMap()));
     }
 
     @Override
     public TaskResult execute(Variables input) {
-        Map<String, Object> result = delegate.execute(TaskParams.of(input, context.defaultVariables().toMap()));
+        Map<String, Object> result = delegate.execute(TaskParams.of(input, defaults, context.defaultVariables().toMap()));
         return TaskResult.of(MapUtils.getBoolean(result, "success", false))
                 .values(result);
     }
 
     public boolean isMemberOf(String userDn, String groupDn) {
-        LdapSearchParams searchParams = TaskParams.searchParams(new MapBackedVariables(Collections.emptyMap()), context.defaultVariables().toMap());
+        LdapSearchParams searchParams = TaskParams.searchParams(new MapBackedVariables(Collections.emptyMap()), defaults, context.defaultVariables().toMap());
         return new LdapTaskCommon().isMemberOf(searchParams, userDn, groupDn);
     }
 }


### PR DESCRIPTION
```
configuration:
  runtime: concord-v2
...
  arguments:
    ldapParams:
      dnsSrvRr: 
        name: "_ldap._tcp.domain.com"
        protocol: "ldaps"
        port: "3269"
```
* added support for `ldapParams` in v2
* cleaned up duplicate retries