### PR TITLE
argocd: add support for azure ad auth

### DIFF
--- a/tasks/argocd/pom.xml
+++ b/tasks/argocd/pom.xml
@@ -96,6 +96,13 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.microsoft.identity.client/msal -->
+        <!-- https://mvnrepository.com/artifact/com.microsoft.azure/msal4j -->
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>msal4j</artifactId>
+            <version>1.13.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdClient.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdClient.java
@@ -54,13 +54,15 @@ public class ArgoCdClient {
         this.baseUrl = in.baseUrl();
     }
 
-    public String auth(TaskParams.AuthParams in) throws IOException {
+    public String auth(TaskParams.AuthParams in) throws Exception {
         if (in instanceof TaskParams.BasicAuth) {
             return authValue(BasicAuthHandler.auth(this, (TaskParams.BasicAuth) in));
         } else if(in instanceof TaskParams.LdapAuth) {
             TokenCookieJar tokenCookieJar = LdapAuthHandler.auth(this, (TaskParams.LdapAuth) in);
             this.client = client.newBuilder().cookieJar(tokenCookieJar).build();
             return authValue(tokenCookieJar.token);
+        } else if (in instanceof TaskParams.AzureAuth) {
+            return authValue(AzureAuthHandler.auth((TaskParams.AzureAuth) in));
         } else if (in instanceof TaskParams.TokenAuth) {
             return authValue(TokenAuthHandler.auth((TaskParams.TokenAuth)in));
         }

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/AzureAuthCache.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/AzureAuthCache.java
@@ -1,0 +1,66 @@
+package com.walmartlabs.concord.plugins.argocd;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.microsoft.aad.msal4j.IAccount;
+import com.microsoft.aad.msal4j.PublicClientApplication;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class AzureAuthCache {
+
+    private final Set<IAccount> accountsInCache;
+    private PublicClientApplication pca;
+
+    private static final AzureAuthCache azureAuthCache = new AzureAuthCache();
+
+
+    public static AzureAuthCache getInstance() {
+        return azureAuthCache;
+    }
+
+    private AzureAuthCache() {
+        accountsInCache = new HashSet<>();
+        pca = null;
+    }
+
+    public void putIAccounts(Set<IAccount> accounts) {
+        accountsInCache.addAll(accounts);
+    }
+
+    public Set<IAccount> getIAccounts() {
+        return accountsInCache;
+    }
+
+    public void setPca(PublicClientApplication pca) {
+        this.pca = pca;
+    }
+
+    public PublicClientApplication getPca() {
+        return this.pca;
+    }
+
+    public void clear() {
+        accountsInCache.clear();
+        pca = null;
+    }
+}

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/AzureAuthHandler.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/AzureAuthHandler.java
@@ -1,0 +1,122 @@
+package com.walmartlabs.concord.plugins.argocd;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2023 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.microsoft.aad.msal4j.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.util.Set;
+
+public class AzureAuthHandler {
+
+    private final static Logger log = LoggerFactory.getLogger(AzureAuthHandler.class);
+
+    public static String auth(TaskParams.AzureAuth auth) throws Exception {
+        PublicClientApplication pca = getPca(AzureAuthCache.getInstance().getPca(), auth.clientId(), auth.authority());
+
+        IAccount account = getAccountByUsername(AzureAuthCache.getInstance().getIAccounts(), auth.username());
+
+        //Attempt to acquire token when user's account is not in the application's token cache/not
+        IAuthenticationResult result = acquireTokenUsernamePassword(pca, auth.scope(), account, auth.username(), auth.password());
+
+        Set<IAccount> accounts = pca.getAccounts().join();
+        AzureAuthCache.getInstance().putIAccounts(accounts);
+        AzureAuthCache.getInstance().setPca(pca);
+
+        return result.idToken();
+    }
+
+    private static IAuthenticationResult acquireTokenUsernamePassword(PublicClientApplication pca,
+                                                                      Set<String> scope,
+                                                                      IAccount account,
+                                                                      String username,
+                                                                      String password) throws Exception {
+        IAuthenticationResult result;
+        try {
+            SilentParameters silentParameters =
+                    SilentParameters
+                            .builder(scope)
+                            .account(account)
+                            .build();
+            // Try to acquire token silently. This will fail on the first acquireTokenUsernamePassword() call
+            // because the token cache does not have any data for the user you are trying to acquire a token for
+            result = pca.acquireTokenSilently(silentParameters).join();
+            log.info("==acquireTokenSilently call succeeded");
+        } catch (Exception ex) {
+            if (ex.getCause() instanceof MsalException) {
+                log.info("==acquireTokenSilently call failed: " + ex.getMessage());
+                UserNamePasswordParameters parameters =
+                        UserNamePasswordParameters
+                                .builder(scope, username, password.toCharArray())
+                                .build();
+                // Try to acquire a token via username/password. If successful, you should see
+                // the token and account information
+                result = pca.acquireToken(parameters).join();
+                log.info("==username/password flow succeeded");
+                log.info("Account username: " + result.account().username());
+            } else {
+                // Handle other exceptions accordingly
+                throw ex;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Helper function to return an account from a given set of accounts based on the given username,
+     * or return null if no accounts in the set match
+     */
+    private static IAccount getAccountByUsername(Set<IAccount> accounts, String username) {
+        if (accounts == null || accounts.isEmpty()) {
+            System.out.println("==No accounts in cache");
+        } else {
+            System.out.println("==Accounts in cache: " + accounts.size());
+            for (IAccount account : accounts) {
+                if (account.username().equalsIgnoreCase(username)) {
+                    return account;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Helper function to return pca from cache,
+     * or return fresh pca if no pca in the set match the clientId
+     */
+    private static PublicClientApplication getPca(PublicClientApplication pca, String clientId, String authority) throws MalformedURLException {
+        if (pca != null && pca.clientId().equalsIgnoreCase(clientId) && removeLastCharIfSlash(pca.authority()).equalsIgnoreCase(removeLastCharIfSlash(authority))) {
+            return pca;
+        }
+        return PublicClientApplication.builder(clientId)
+                .authority(authority)
+                .build();
+    }
+
+    private static String removeLastCharIfSlash(String s) {
+        if (s == null || s.length() == 0 || s.charAt(s.length() - 1) != '/') {
+            return s;
+        }
+        return s.substring(0, s.length() - 1);
+    }
+}

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParams.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParams.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface TaskParams {
 
@@ -46,6 +47,20 @@ public interface TaskParams {
         default String connectorId() {
             return "ldap";
         }
+
+        String username();
+
+        String password();
+    }
+
+    interface AzureAuth extends AuthParams {
+
+        String clientId();
+
+        String authority();
+
+        @Value.Default
+        default Set<String> scope() { return Collections.singleton("user.read"); }
 
         String username();
 

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
@@ -82,6 +82,7 @@ public class TaskParamsImpl implements TaskParams {
         result.put("basic", BasicAuthImpl::new);
         result.put("ldap", LdapAuthImpl::new);
         result.put("token", TokenAuthImpl::new);
+        result.put("azure", AzureAuthImpl::new);
         return result;
     }
 
@@ -195,6 +196,45 @@ public class TaskParamsImpl implements TaskParams {
         @Override
         public String connectorId() {
             return variables.getString(CONNECTOR_ID_KEY, LdapAuth.super.connectorId());
+        }
+
+        @Override
+        public String username() {
+            return variables.assertString(USERNAME_KEY);
+        }
+
+        @Override
+        public String password() {
+            return variables.assertString(PASSWORD_KEY);
+        }
+    }
+
+    private static class AzureAuthImpl implements AzureAuth {
+
+        private static final String USERNAME_KEY = "username";
+        private static final String PASSWORD_KEY = "password";
+        private static final String CLIENT_ID_KEY = "clientId";
+        private static final String AUTHORITY_KEY = "authority";
+        private static final String SCOPE_KEY = "scope";
+
+
+        private final Variables variables;
+
+        private AzureAuthImpl(Variables variables) {
+            this.variables = variables;
+        }
+
+        @Override
+        public String clientId() {
+            return variables.assertString(CLIENT_ID_KEY);
+        }
+
+        @Override
+        public String authority() { return variables.assertString(AUTHORITY_KEY); }
+
+        @Override
+        public Set<String> scope() {
+            return new HashSet<>(variables.getCollection(SCOPE_KEY, AzureAuth.super.scope()));
         }
 
         @Override

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImplTest.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImplTest.java
@@ -23,9 +23,7 @@ package com.walmartlabs.concord.plugins.argocd;
 import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -68,5 +66,27 @@ public class TaskParamsImplTest {
         assertTrue(in.auth() instanceof TaskParams.BasicAuth);
         assertEquals("duke", ((TaskParams.BasicAuth)in.auth()).username());
         assertEquals("nukem", ((TaskParams.BasicAuth)in.auth()).password());
+    }
+
+    @Test
+    public void testAzureAuth() {
+        Map<String, Object> authParams = new HashMap<>();
+        authParams.put("username", "duke");
+        authParams.put("password", "nukem");
+        authParams.put("clientId", "client-1");
+        authParams.put("authority", "https://login.azure.com/cleint-1");
+        authParams.put("scope", Collections.unmodifiableSet(new HashSet<>(Arrays.asList("user.read", "user.write"))));
+
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("action", TaskParams.Action.GET.name());
+        vars.put("auth", Collections.singletonMap("azure", authParams));
+
+        TaskParams.GetParams in = (TaskParams.GetParams) TaskParamsImpl.of(new MapBackedVariables(vars), Collections.emptyMap());
+        assertTrue(in.auth() instanceof TaskParams.AzureAuth);
+        assertEquals("duke", ((TaskParams.AzureAuth)in.auth()).username());
+        assertEquals("nukem", ((TaskParams.AzureAuth)in.auth()).password());
+        assertEquals("client-1", ((TaskParams.AzureAuth)in.auth()).clientId());
+        assertEquals("https://login.azure.com/cleint-1", ((TaskParams.AzureAuth)in.auth()).authority());
+        assertTrue(((TaskParams.AzureAuth)in.auth()).scope().contains("user.read"));
     }
 }

--- a/tasks/argocd/src/test/resources/example-flow/concord.yml
+++ b/tasks/argocd/src/test/resources/example-flow/concord.yml
@@ -23,6 +23,7 @@ flows:
         auth: ${defaults.auth}
         validateCerts: ${defaults.validateCerts}
         syncTimeout: ${defaults.syncTimeout}
+        resources: []
       out: syncResult
 
     - log: ${syncResult}


### PR DESCRIPTION
```
configuration:
  runtime: concord-v2
  arguments:
    defaults:
      baseUrl: "http://argo.net"  # replace with actual url
      auth:
        azure:
          clientId: <client_id>
          authority: <authority>     #https://login.microsoftonline.com/<tenantId>/<Version>
          scope:
            - "user.read"
          username: username@domain.com
          password:  *****
```