### PR TITLE
git: rollback version to 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
         <scm.connection>scm:git:https://github.com/walmartlabs/concord-plugins.git</scm.connection>
 
-        <concord.version>1.96.0</concord.version>
+        <concord.version>1.101.0</concord.version>
         <wiremock.version>2.27.2</wiremock.version>
     </properties>
 

--- a/tasks/git/pom.xml
+++ b/tasks/git/pom.xml
@@ -14,7 +14,8 @@
     <packaging>takari-jar</packaging>
 
     <properties>
-        <jgit.version>6.5.0.202303070854-r</jgit.version>
+        <jgit.version>5.13.1.202206130422-r</jgit.version>
+        <egit.github.version>5.13.0.202109080827-r</egit.github.version>
     </properties>
 
     <dependencies>
@@ -75,7 +76,7 @@
         <dependency>
             <groupId>org.eclipse.mylyn.github</groupId>
             <artifactId>org.eclipse.egit.github.core</artifactId>
-            <version>6.1.0.202203080745-r</version>
+            <version>${egit.github.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/tasks/git/src/main/java/com/walmartlabs/concord/plugins/git/JGitClient.java
+++ b/tasks/git/src/main/java/com/walmartlabs/concord/plugins/git/JGitClient.java
@@ -29,8 +29,6 @@ import com.walmartlabs.concord.sdk.Secret;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.transport.*;
-import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.ssh.jsch.OpenSshConfig;
 import org.eclipse.jgit.util.FS;
 
 import java.nio.file.Path;


### PR DESCRIPTION
we still have concord instance with 1.8 java