### PR TITLE
argocd: optional `spec` option to provide additional params for app creation

### DIFF
--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdConstants.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdConstants.java
@@ -26,7 +26,7 @@ public class ArgoCdConstants {
 
     static final List<String> FINALIZERS = Collections.singletonList("resources-finalizer.argocd.argoproj.io");
 
-    static final List<String> CREATE_NAMESPACE_OPTION = Collections.singletonList("CreateNamespace=true");
+    static final String CREATE_NAMESPACE_OPTION = "CreateNamespace=true";
 
     static final Map<String, Object> SYNC_POLICY = Collections.unmodifiableMap(new HashMap<String, Object>() {{
         put("automated", new HashMap<String, Object>() {{

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ObjectMapper.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ObjectMapper.java
@@ -27,12 +27,15 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1Application;
 import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1ApplicationSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Collections;
 
 public class ObjectMapper {
 
@@ -84,11 +87,10 @@ public class ObjectMapper {
         Map<String, Object> destination = new HashMap<>();
         Map<String, Object> body = new HashMap<>();
         Map<String, Object> spec = new HashMap<>();
+        Map<String, Object> helm = new HashMap<>();
 
         if (in.spec() != null)
             spec = Objects.requireNonNull(in.spec());
-
-        Map<String, Object> helm = new HashMap<>();
 
         metadata.put("name", in.app());
         metadata.put("namespace", ArgoCdConstants.ARGOCD_NAMESPACE);

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ObjectMapper.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ObjectMapper.java
@@ -27,12 +27,12 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1Application;
 import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1ApplicationSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 public class ObjectMapper {
 
@@ -80,11 +80,15 @@ public class ObjectMapper {
 
     public V1alpha1Application buildApplicationObject(TaskParams.CreateUpdateParams in) throws IOException {
         Map<String, Object> metadata = new HashMap<>();
-        Map<String, Object> spec = new HashMap<>();
         Map<String, Object> source = new HashMap<>();
-        Map<String, Object> helm = new HashMap<>();
         Map<String, Object> destination = new HashMap<>();
         Map<String, Object> body = new HashMap<>();
+        Map<String, Object> spec = new HashMap<>();
+
+        if (in.spec() != null)
+            spec = Objects.requireNonNull(in.spec());
+
+        Map<String, Object> helm = new HashMap<>();
 
         metadata.put("name", in.app());
         metadata.put("namespace", ArgoCdConstants.ARGOCD_NAMESPACE);
@@ -96,6 +100,11 @@ public class ObjectMapper {
 
         destination.put("namespace", in.namespace());
         destination.put("name", in.cluster());
+
+        // check if there is an existing `source` defined as part of spec
+        // merge the values from the parameters passed into spec if defined
+        if (spec.get("source") != null && spec.get("source") instanceof Map)
+            source = (Map<String, Object>) spec.get("source");
 
         if (in.gitRepo() != null) {
             source.put("repoURL", Objects.requireNonNull(in.gitRepo()).repoUrl());
@@ -112,23 +121,53 @@ public class ObjectMapper {
         }
 
         if (in.helm() != null) {
+
+            // check if there is `helm` defined as part of source. Merge the values
+            // from the parameters passed into existing helm params if defined
+            if (source.get("helm") != null && source.get("helm") instanceof Map)
+                helm = (Map<String, Object>) source.get("helm");
+
             if (Objects.requireNonNull(in.helm()).parameters() != null)
                 helm.put("parameters", Objects.requireNonNull(in.helm()).parameters());
 
             helm.put("values", Objects.requireNonNull(in.helm()).values());
+
+            if (Objects.requireNonNull(in.helm()).releaseName() != null)
+                helm.put("releaseName", Objects.requireNonNull(in.helm()).releaseName());
+
+            helm.put("skipCrds", Objects.requireNonNull(in.helm()).skipCrds());
+            helm.put("ignoreMissingValueFiles", Objects.requireNonNull(in.helm()).ignoreMissingValueFiles());
+
             source.put("helm", helm);
         }
         spec.put("project", in.project());
         spec.put("destination", destination);
         spec.put("source", source);
 
-        if (in.createNamespace()) {
-            Map<String, Object> syncPolicy = new HashMap<>(ArgoCdConstants.SYNC_POLICY);
-            syncPolicy.put("syncOptions", ArgoCdConstants.CREATE_NAMESPACE_OPTION);
-            spec.put("syncPolicy", syncPolicy);
+        Map<String, Object> syncPolicy;
+
+        if (spec.get("syncPolicy") != null && spec.get("syncPolicy") instanceof Map) {
+            syncPolicy = (Map<String, Object>) spec.get("syncPolicy");
+
+            List<String> syncOptions;
+
+            if (syncPolicy.get("syncOptions") != null && syncPolicy.get("syncOptions") instanceof List)
+                syncOptions = (List<String>) syncPolicy.get("syncOptions");
+            else
+                syncOptions = new ArrayList<>();
+
+            if (in.createNamespace() && (syncOptions.isEmpty() ||
+                    syncOptions.stream().noneMatch(ArgoCdConstants.CREATE_NAMESPACE_OPTION::equalsIgnoreCase))) {
+                syncOptions.add(ArgoCdConstants.CREATE_NAMESPACE_OPTION);
+                syncPolicy.put("syncOptions", syncOptions);
+            }
         } else {
-            spec.put("syncPolicy", ArgoCdConstants.SYNC_POLICY);
+            syncPolicy = new HashMap<>(ArgoCdConstants.SYNC_POLICY);
+            if (in.createNamespace())
+                syncPolicy.put("syncOptions", Collections.singletonList(ArgoCdConstants.CREATE_NAMESPACE_OPTION));
         }
+
+        spec.put("syncPolicy", syncPolicy);
 
         body.put("metadata", metadata);
         body.put("spec", spec);

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParams.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParams.java
@@ -212,6 +212,9 @@ public interface TaskParams {
         @Nullable
         Map<String, String> annotations();
 
+        @Nullable
+        Map<String, Object> spec();
+
         interface GitRepo {
             String repoUrl();
 
@@ -233,6 +236,19 @@ public interface TaskParams {
             List<Map<String, Object>> parameters();
 
             String values();
+
+            @Nullable
+            String releaseName();
+
+            @Value.Default
+            default boolean skipCrds() {
+                return true;
+            }
+
+            @Value.Default
+            default boolean ignoreMissingValueFiles() {
+                return true;
+            }
         }
     }
 

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
@@ -400,6 +400,7 @@ public class TaskParamsImpl implements TaskParams {
         private static final String HELM_KEY = "helm";
         private static final String ANNOTATIONS_KEY = "annotations";
         private static final String SYNC_TIMEOUT_KEY = "syncTimeout";
+        private static final String SPEC_KEY = "spec";
 
         protected CreateParamsImpl(Variables variables) {
             super(variables);
@@ -428,6 +429,11 @@ public class TaskParamsImpl implements TaskParams {
         @Override
         public String project() {
             return variables.getString(PROJECT_KEY, "default");
+        }
+
+        @Override
+        public Map<String, Object> spec() {
+            return variables.getMap(SPEC_KEY, null);
         }
 
         @Nullable
@@ -548,6 +554,10 @@ public class TaskParamsImpl implements TaskParams {
 
             private static final String PARAMS_KEY = "parameters";
             private static final String VALUES_KEY = "values";
+            private static final String RELEASE_NAME_KEY = "releaseName";
+            private static final String VERSION_KEY = "version";
+            private static final String SKIP_CRDS_KEY = "skipCrds";
+            private static final String IGNORE_MISSING_VALUE_FILES_KEY = "ignoreMissingValueFiles";
 
             private final Variables variables;
 
@@ -564,6 +574,22 @@ public class TaskParamsImpl implements TaskParams {
             public String values() {
                 return variables.assertString(VALUES_KEY);
             }
+
+            @Override
+            public String releaseName() {
+                return variables.getString(RELEASE_NAME_KEY, null);
+            }
+
+            @Override
+            public boolean skipCrds() {
+                return variables.getBoolean(SKIP_CRDS_KEY, Helm.super.skipCrds());
+            }
+
+            @Override
+            public boolean ignoreMissingValueFiles() {
+                return variables.getBoolean(IGNORE_MISSING_VALUE_FILES_KEY, Helm.super.ignoreMissingValueFiles());
+            }
+
         }
     }
 


### PR DESCRIPTION
`spec` option where users can specify additional options (not available as task parameters) as part of ArgoCD application creation. 

NOTE: 
1. if any of the mandatory task parameters are also defined as part of the `spec` parameter, they will be overridden by the values provided by the task parameters. 
2. Optional Task parameters could be skipped and provided as part of the `spec` parameter itself. But if they are defined in both places, the values provided as part of the task parameters will be given preference over the values provided for the same parameters as part of the spec.

Examples:

1. Using kustomize instead of helm
```
flows:
  default:
     - task: argocd
        in:
          action: create
          app: test-app
          gitRepo:
            repoUrl: https://github.com/myorg/myrepo.git
            targetRevision: HEAD
            path: test
          project: test-proj
          namespace: test-ns
          cluster: in-cluster
          spec:
            source:
              kustomize:
                namePrefix: test-prefix
                nameSuffix: test-suffix
        out: result
```

2. Additional sync options
```
flows:
  default:
     - task: argocd
        in:
          action: create
          app: test-app
          gitRepo:
            repoUrl: https://github.com/myorg/myrepo.git
            targetRevision: HEAD
            path: test
          project: test-proj
          namespace: test-ns
          createNamespace: true
          cluster: in-cluster
          spec:
            syncPolicy:
              automated:
                selfHeal: true
                prune: true
              syncOptions:
                - ApplyOutOfSyncOnly=true
        out: result
```
In this case the `syncPolicy` parameters provided will be passed on to the ArgoCD application manifest. And `createNamespace: true` option will be merged with the `syncOptions` provided as part of the `spec` parameter. 

Alternatively, `CreateNamespace=true` can be provided as part of `syncOptions` in `spec` instead of the task parameter `createNamespace`.