### PR TITLE
argocd: new params for UpdateSpec and CreateUpdate actions. fix timeout issues

### DIFF
--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdClient.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdClient.java
@@ -236,7 +236,7 @@ public class ArgoCdClient {
             return Optional.empty();
         };
 
-        return new CallRetry<>(mainAttempt, fallback, List.of(SocketTimeoutException.class) ).attemptWithRetry(RETRY_LIMIT);
+        return new CallRetry<>(mainAttempt, fallback, Set.of(SocketTimeoutException.class) ).attemptWithRetry(RETRY_LIMIT);
     }
 
     private static String healthStatus(V1alpha1Application app) {

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdClient.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdClient.java
@@ -51,6 +51,7 @@ import javax.net.ssl.SSLContext;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -137,8 +138,8 @@ public class ArgoCdClient {
                                                 WaitWatchParams p,
                                                 ApplicationServiceApi appApi) throws Exception {
 
-            try (CloseableHttpResponse response = client.getHttpClient().execute(request);
-                 BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))) {
+            try (CloseableHttpResponse response = client.getHttpClient().execute(request)) {
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
                 String line;
 
                 while ((line = bufferedReader.readLine()) != null) {
@@ -235,7 +236,7 @@ public class ArgoCdClient {
             return Optional.empty();
         };
 
-        return new CallRetry<>(mainAttempt, fallback).attemptWithRetry(RETRY_LIMIT);
+        return new CallRetry<>(mainAttempt, fallback, List.of(SocketTimeoutException.class) ).attemptWithRetry(RETRY_LIMIT);
     }
 
     private static String healthStatus(V1alpha1Application app) {

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdTask.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdTask.java
@@ -181,7 +181,9 @@ public class ArgoCdTask implements Task {
             appSpec = ConfigurationUtils.deepMerge(appSpec, in.spec());
             V1alpha1ApplicationSpec specObject = objectMapper.mapToModel(appSpec, V1alpha1ApplicationSpec.class);
             V1alpha1ApplicationSpec result = client.updateAppSpec(in.app(), specObject);
-
+            if(in.waitForSync()) {
+               client.waitForSync(in.app(), app.getMetadata().getResourceVersion(), in.syncTimeout(), toWatchParams(in.watchHealth()));
+            }
             return TaskResult.success()
                     .value("spec", toMap(result));
         } finally {
@@ -261,8 +263,10 @@ public class ArgoCdTask implements Task {
             V1alpha1Application application = objectMapper.buildApplicationObject(in);
             ArgoCdClient client = new ArgoCdClient(in);
             V1alpha1Application app = client.createApp(application, in.upsert());
-            app = client.waitForSync(in.app(), app.getMetadata().getResourceVersion(), in.syncTimeout(),
-                    toWatchParams(false));
+            if(in.waitForSync()){
+                app = client.waitForSync(in.app(), app.getMetadata().getResourceVersion(), in.syncTimeout(),
+                        toWatchParams(in.watchHealth()));
+            }
             return TaskResult.success()
                     .value("app", toMap(app));
         } finally {

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdTask.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdTask.java
@@ -181,7 +181,7 @@ public class ArgoCdTask implements Task {
             appSpec = ConfigurationUtils.deepMerge(appSpec, in.spec());
             V1alpha1ApplicationSpec specObject = objectMapper.mapToModel(appSpec, V1alpha1ApplicationSpec.class);
             V1alpha1ApplicationSpec result = client.updateAppSpec(in.app(), specObject);
-            if(in.waitForSync()) {
+            if (in.waitForSync()) {
                client.waitForSync(in.app(), app.getMetadata().getResourceVersion(), in.syncTimeout(), toWatchParams(in.watchHealth()));
             }
             return TaskResult.success()
@@ -263,7 +263,7 @@ public class ArgoCdTask implements Task {
             V1alpha1Application application = objectMapper.buildApplicationObject(in);
             ArgoCdClient client = new ArgoCdClient(in);
             V1alpha1Application app = client.createApp(application, in.upsert());
-            if(in.waitForSync()){
+            if (in.waitForSync()){
                 app = client.waitForSync(in.app(), app.getMetadata().getResourceVersion(), in.syncTimeout(),
                         toWatchParams(in.watchHealth()));
             }

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/CallRetry.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/CallRetry.java
@@ -23,23 +23,24 @@ package com.walmartlabs.concord.plugins.argocd;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.Callable;
 
 public class CallRetry<R> {
     private static final Logger log = LoggerFactory.getLogger(CallRetry.class);
     private final Callable<R> mainAttempt;
     private final Collection<Callable<Optional<R>>> fallbackAttempts;
+    private final List<Class<? extends Exception>> exceptionsToNotRetry;
 
     /**
      * @param mainAttempt Primary call to attempt to execute
      * @param fallbackAttempt Fallback call which will be attempted if the main call throws an exception.
+     * @param exceptionsToNotRetry dont retry for these exceptions
      */
-    public CallRetry(Callable<R> mainAttempt, Callable<Optional<R>> fallbackAttempt) {
+    public CallRetry(Callable<R> mainAttempt, Callable<Optional<R>> fallbackAttempt, List<Class<? extends Exception>> exceptionsToNotRetry) {
         this.mainAttempt = mainAttempt;
         this.fallbackAttempts = Collections.singleton(fallbackAttempt);
+        this.exceptionsToNotRetry = exceptionsToNotRetry;
     }
 
     /**
@@ -50,23 +51,33 @@ public class CallRetry<R> {
      * @return Results of main call, or fallback result if data is present after main failure
      */
     public R attemptWithRetry(int maxTries) {
+        log.info("attempt with retry start {}", new Date().toString());
         Throwable lastError = null;
 
         int attemptsMade = 0;
         while (attemptsMade++ < maxTries) {
             try {
-                return mainAttempt.call();
+                R out = mainAttempt.call();
+                log.info("after main attempt {}", new Date().toString());
+                return out;
             } catch (Exception e) {
+                if(exceptionsToNotRetry.stream().anyMatch(exceptionToNotRetry -> e.getClass().equals(exceptionToNotRetry))) {
+                    throw new RuntimeException(e);
+                }
+                log.info("Exception in main attempt {}, e", new Date().toString(), e);
                 lastError = e;
             }
 
             // if any of these returns cleanly then that's good enough
             for (Callable<Optional<R>> c : fallbackAttempts) {
+                log.info("Running fallback attempt {}", new Date().toString());
                 try {
                     Optional<R> result = c.call();
 
                     if (result.isPresent()) {
-                        return result.get();
+                        R out = result.get();
+                        log.info("after fallback attempt {}", new Date().toString());
+                        return out;
                     }
                 } catch (Exception e) {
                     log.warn("Error attempting fallback: {}", e.getMessage());

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/CallRetry.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/CallRetry.java
@@ -56,12 +56,15 @@ public class CallRetry<R> {
         int attemptsMade = 0;
         while (attemptsMade++ < maxTries) {
             try {
-                R out = mainAttempt.call();
-                return out;
+                return mainAttempt.call();
             } catch (Exception e) {
-                if(exceptionsToNotRetry.stream().anyMatch(exceptionToNotRetry -> exceptionToNotRetry.isInstance(e))) {
+                boolean isNotRetryable = exceptionsToNotRetry.stream()
+                        .anyMatch(clazz -> clazz.isInstance(e));
+
+                if (isNotRetryable) {
                     throw new RuntimeException(e);
                 }
+
                 lastError = e;
             }
 

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParams.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParams.java
@@ -217,6 +217,12 @@ public interface TaskParams {
         @Nullable
         Map<String, Object> spec();
 
+        @Value.Default
+        default boolean waitForSync() { return true; }
+
+        @Value.Default
+        default boolean watchHealth() { return false; }
+
         interface GitRepo {
             String repoUrl();
 
@@ -266,6 +272,15 @@ public interface TaskParams {
         String app();
 
         Map<String, Object> spec();
+
+        @Value.Default
+        default boolean waitForSync() { return false; }
+
+        @Value.Default
+        default boolean watchHealth() { return false; }
+
+        @Nullable
+        Duration syncTimeout();
     }
 
     interface SetAppParams extends TaskParams {

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
@@ -884,7 +884,7 @@ public class TaskParamsImpl implements TaskParams {
         }
     }
 
-    public static class SyncParamsImpl extends TaskParamsImpl implements SyncParams {
+    private static class SyncParamsImpl extends TaskParamsImpl implements SyncParams {
 
         private static class ResourceImpl implements SyncParams.Resource {
 

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImpl.java
@@ -427,6 +427,8 @@ public class TaskParamsImpl implements TaskParams {
         private static final String SYNC_TIMEOUT_KEY = "syncTimeout";
         private static final String SPEC_KEY = "spec";
         private static final String UPSERT_KEY = "upsert";
+        private static final String WAIT_FOR_SYNC_KEY = "waitForSync";
+        private static final String WATCH_HEALTH_KEY = "watchHealth";
 
         protected CreateParamsImpl(Variables variables) {
             super(variables);
@@ -445,6 +447,16 @@ public class TaskParamsImpl implements TaskParams {
         @Override
         public String namespace() {
             return variables.assertString(NAMESPACE_KEY);
+        }
+
+        @Override
+        public boolean waitForSync() {
+            return variables.getBoolean(WAIT_FOR_SYNC_KEY, CreateUpdateParams.super.waitForSync());
+        }
+
+        @Override
+        public boolean watchHealth() {
+            return variables.getBoolean(WATCH_HEALTH_KEY, CreateUpdateParams.super.watchHealth());
         }
 
         @Override
@@ -759,10 +771,35 @@ public class TaskParamsImpl implements TaskParams {
 
         private static final String APP_KEY = "app";
         private static final String SPEC_KEY = "spec";
+        private static final String WAIT_FOR_SYNC_KEY = "waitForSync";
+        private static final String WATCH_HEALTH_KEY = "watchHealth";
+        private static final String SYNC_TIMEOUT_KEY = "syncTimeout";
 
         protected UpdateSpecParamsImpl(Variables variables) {
             super(variables);
         }
+
+        @Nullable
+        @Override
+        public Duration syncTimeout() {
+            String value = variables.getString(SYNC_TIMEOUT_KEY);
+            if (value == null) {
+                return null;
+            }
+
+            return Duration.parse(value);
+        }
+
+        @Override
+        public boolean waitForSync() {
+            return variables.getBoolean(WAIT_FOR_SYNC_KEY, UpdateSpecParams.super.waitForSync());
+        }
+
+        @Override
+        public boolean watchHealth() {
+            return variables.getBoolean(WATCH_HEALTH_KEY, UpdateSpecParams.super.watchHealth());
+        }
+
 
         @Override
         public String app() {
@@ -847,7 +884,7 @@ public class TaskParamsImpl implements TaskParams {
         }
     }
 
-    private static class SyncParamsImpl extends TaskParamsImpl implements SyncParams {
+    public static class SyncParamsImpl extends TaskParamsImpl implements SyncParams {
 
         private static class ResourceImpl implements SyncParams.Resource {
 

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/CallRetryTest.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/CallRetryTest.java
@@ -75,7 +75,7 @@ class CallRetryTest {
         when(primaryResp.call()).thenThrow(new SocketTimeoutException("forced exception"));
         CallRetry<String> callRetry = new CallRetry<>(primaryResp, fallbackResp, Set.of(SocketTimeoutException.class));
         Exception e = assertThrows(RuntimeException.class, () -> callRetry.attemptWithRetry(2));
-        assertEquals(e.getMessage(), "java.net.SocketTimeoutException: forced exception");
+        assertEquals("java.net.SocketTimeoutException: forced exception", e.getMessage());
         verify(primaryResp, times(1)).call();
         verify(fallbackResp, times(0)).call();
     }

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/CallRetryTest.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/CallRetryTest.java
@@ -31,6 +31,7 @@ import java.net.SocketTimeoutException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,7 +51,7 @@ class CallRetryTest {
     void test() throws Exception {
         when(primaryResp.call()).thenReturn("a");
 
-        String result = new CallRetry<>(primaryResp, fallbackResp, Collections.emptyList()).attemptWithRetry(2);
+        String result = new CallRetry<>(primaryResp, fallbackResp, Collections.emptySet()).attemptWithRetry(2);
 
         assertEquals("a", result);
         verify(primaryResp, times(1)).call();
@@ -62,7 +63,7 @@ class CallRetryTest {
         when(primaryResp.call()).thenThrow(new IllegalStateException("forced exception"));
         when(fallbackResp.call()).thenReturn(Optional.of("b"));
 
-        String result = new CallRetry<>(primaryResp, fallbackResp, Collections.emptyList()).attemptWithRetry(2);
+        String result = new CallRetry<>(primaryResp, fallbackResp, Collections.emptySet()).attemptWithRetry(2);
 
         assertEquals("b", result);
         verify(primaryResp, times(1)).call();
@@ -72,7 +73,7 @@ class CallRetryTest {
     @Test
     void testPrimaryFailWithExpectedException() throws Exception {
         when(primaryResp.call()).thenThrow(new SocketTimeoutException("forced exception"));
-        CallRetry<String> callRetry = new CallRetry<>(primaryResp, fallbackResp, List.of(SocketTimeoutException.class));
+        CallRetry<String> callRetry = new CallRetry<>(primaryResp, fallbackResp, Set.of(SocketTimeoutException.class));
         Exception e = assertThrows(RuntimeException.class, () -> callRetry.attemptWithRetry(2));
         assertEquals(e.getMessage(), "java.net.SocketTimeoutException: forced exception");
         verify(primaryResp, times(1)).call();
@@ -94,7 +95,7 @@ class CallRetryTest {
         });
         when(fallbackResp.call()).thenReturn(Optional.empty());
 
-        String result = new CallRetry<>(primaryResp, fallbackResp, Collections.emptyList()).attemptWithRetry(2);
+        String result = new CallRetry<>(primaryResp, fallbackResp, Collections.emptySet()).attemptWithRetry(2);
 
         assertEquals("a", result);
         verify(primaryResp, times(2)).call();

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImplTest.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/TaskParamsImplTest.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.plugins.argocd;
 import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -89,4 +90,37 @@ public class TaskParamsImplTest {
         assertEquals("https://login.azure.com/cleint-1", ((TaskParams.AzureAuth)in.auth()).authority());
         assertTrue(((TaskParams.AzureAuth)in.auth()).scope().contains("user.read"));
     }
+
+
+    @Test
+    public void testUpdateSpecParams() {
+        Map<String, Object> authParams = new HashMap<>();
+
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("action", TaskParams.Action.UPDATESPEC.name());
+        vars.put("auth", Collections.singletonMap("azure", authParams));
+        vars.put("syncTimeout", "PT5M");
+
+        TaskParams.UpdateSpecParams in = (TaskParams.UpdateSpecParams) TaskParamsImpl.of(new MapBackedVariables(vars), Collections.emptyMap());
+        assertFalse(in.waitForSync());
+        assertFalse(in.watchHealth());
+        assertEquals(in.syncTimeout(), Duration.parse("PT5M"));
+    }
+
+
+    @Test
+    public void testCreateSpecParams() {
+        Map<String, Object> authParams = new HashMap<>();
+
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("action", TaskParams.Action.CREATE.name());
+        vars.put("auth", Collections.singletonMap("azure", authParams));
+        vars.put("syncTimeout", "PT5M");
+
+        TaskParams.CreateUpdateParams in = (TaskParams.CreateUpdateParams) TaskParamsImpl.of(new MapBackedVariables(vars), Collections.emptyMap());
+        assertTrue(in.waitForSync());
+        assertFalse(in.watchHealth());
+        assertEquals(in.syncTimeout(), Duration.parse("PT5M"));
+    }
+
 }


### PR DESCRIPTION
* Add options waitForSync,syncTimeout,watchHealth parameters for UpdateSpec and CreateUpdate operations
* Fixed timeout issues for waitForSync method by moving BuffereReader instance creation statement from try-with-resource block.