### PR TITLE
aws: add a basic ecr describe-images wrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <modules>
         <module>tasks/akeyless</module>
         <module>tasks/argocd</module>
+        <module>tasks/aws</module>
         <module>tasks/confluence</module>
         <module>tasks/git</module>
         <module>tasks/gremlin</module>

--- a/tasks/aws/examples/ecr/concord.yml
+++ b/tasks/aws/examples/ecr/concord.yml
@@ -1,0 +1,14 @@
+configuration:
+  runtime: concord-v2
+  dependencies:
+    - mvn://com.walmartlabs.concord.plugins:aws-tasks:2.3.0
+
+flows:
+  default:
+    - task: awsEcr
+      in:
+        action: describe-images
+        region: us-east-1
+        repositoryName: foo
+      out: result
+    - log: "Image Details: ${resource.prettyPrintJson(result.imageDetails)}"

--- a/tasks/aws/pom.xml
+++ b/tasks/aws/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.walmartlabs.concord.plugins</groupId>
+        <artifactId>concord-plugins-parent</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>aws-tasks</artifactId>
+    <packaging>takari-jar</packaging>
+
+    <properties>
+        <aws.sdk.version>2.26.4</aws.sdk.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ecr</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord</groupId>
+            <artifactId>concord-sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.walmartlabs.concord.runtime.v2</groupId>
+            <artifactId>concord-runtime-sdk-v2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tasks/aws/src/main/java/com/walmartlabs/concord/plugins/aws/EcrTask.java
+++ b/tasks/aws/src/main/java/com/walmartlabs/concord/plugins/aws/EcrTask.java
@@ -1,0 +1,95 @@
+package com.walmartlabs.concord.plugins.aws;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.walmartlabs.concord.runtime.v2.sdk.Task;
+import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
+import com.walmartlabs.concord.runtime.v2.sdk.Variables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ecr.EcrClient;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@Named("awsEcr")
+public class EcrTask implements Task {
+
+    private static final Logger log = LoggerFactory.getLogger(EcrTask.class);
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public EcrTask(ObjectMapper objectMapper) {
+        this.objectMapper = requireNonNull(objectMapper).copy()
+                .registerModule(new JavaTimeModule())
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
+
+    @Override
+    public TaskResult execute(Variables input) {
+        var action = input.assertString("action");
+        if ("describe-images".equals(action)) {
+            return describeImages(input);
+        }
+        throw new IllegalArgumentException("Unsupported action: " + action);
+    }
+
+    private TaskResult describeImages(Variables input) {
+        var region = assertRegion(input, "region");
+        var repositoryName = input.assertString("repositoryName");
+        var verbose = input.getBoolean("verbose", false);
+
+        // create the client
+        if (verbose) {
+            log.info("Using region: {}", region);
+        }
+        var client = EcrClient.builder()
+                .region(region)
+                .build();
+
+        // describe-images
+        if (verbose) {
+            log.info("Describing images in repository '{}'", repositoryName);
+        }
+        var result = client.describeImages(r -> r.repositoryName(repositoryName));
+        if (verbose) {
+            log.info("Done: {}", result.imageDetails().size());
+        }
+
+        // serialize result into POJOs
+        var data = objectMapper.convertValue(result.toBuilder(), Map.class);
+        //noinspection unchecked
+        return TaskResult.success().values(data);
+    }
+
+    private static Region assertRegion(Variables input, String key) {
+        String region = input.assertString(key);
+        return Region.of(region);
+    }
+}

--- a/tasks/aws/src/test/java/com/walmartlabs/concord/plugins/aws/EcrTaskTest.java
+++ b/tasks/aws/src/test/java/com/walmartlabs/concord/plugins/aws/EcrTaskTest.java
@@ -1,0 +1,49 @@
+package com.walmartlabs.concord.plugins.aws;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Disabled("requires AWS credentials")
+public class EcrTaskTest {
+
+    @Test
+    public void testDescribeImages() {
+        var task = new EcrTask(new ObjectMapper());
+        var input = new MapBackedVariables(Map.of(
+                "action", "describe-images",
+                "region", "us-east-1",
+                "repositoryName", "foo"
+        ));
+        var result = task.execute(input);
+        assertInstanceOf(TaskResult.SimpleResult.class, result);
+        assertNotNull(((TaskResult.SimpleResult) result).toMap().get("data"));
+    }
+}

--- a/tasks/aws/src/test/resources/logback.xml
+++ b/tasks/aws/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%-5level] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Running tasks/aws/examples/ecr/concord.yml:

```
> concord run
Starting...
15:07:33.142 [main] Image Details: [ {
  "registryId" : "742982124480",
  "repositoryName" : "foo",
  "imageDigest" : "sha256:c49527020d9f72c711eb9ec89ae6162ddd88abebb69b79967c72b1ac56b60769",
  "imageTags" : [ "latest" ],
  "imageSizeInBytes" : 153448492,
  "imagePushedAt" : 1718737639.000000000,
  "imageScanStatus" : null,
  "imageScanFindingsSummary" : null,
  "imageManifestMediaType" : "application/vnd.docker.distribution.manifest.v2+json",
  "artifactMediaType" : "application/vnd.docker.container.image.v1+json",
  "lastRecordedPullTime" : null
} ]
...done!
```