### PR TITLE
jira: enable tests, remove Gson usage, prep for okhttp 2.X removal

### DIFF
--- a/tasks/jira/pom.xml
+++ b/tasks/jira/pom.xml
@@ -13,7 +13,7 @@
     <packaging>takari-jar</packaging>
 
     <properties>
-        <skipTests>true</skipTests>
+        <skipTests>false</skipTests>
     </properties>
 
     <dependencies>
@@ -33,6 +33,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.walmartlabs.concord</groupId>
+            <artifactId>concord-client2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <scope>provided</scope>
@@ -43,10 +48,31 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>${gson.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
@@ -66,6 +92,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/Constants.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/Constants.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.plugins.jira;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc., Concord Authors
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,14 @@ package com.walmartlabs.concord.plugins.jira;
  * =====
  */
 
-import java.util.Base64;
+import java.util.UUID;
 
-public class JiraCredentials {
+public class Constants {
 
-    private final String username;
-    private final String password;
-
-    public JiraCredentials(String username, String password) {
-        this.username = username;
-        this.password = password;
+    private Constants() {
+        throw new IllegalStateException("instantiation is not allowed");
     }
 
-    public String username() {
-        return username;
-    }
+    static final String BOUNDARY = UUID.randomUUID().toString();
 
-    public String password() {
-        return password;
-    }
-
-    public String authHeaderValue() {
-        return "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
-    }
 }

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraClientCfg.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraClientCfg.java
@@ -33,4 +33,31 @@ public interface JiraClientCfg {
     default long writeTimeout() {
         return 30L;
     }
+
+    default HttpVersion httpProtocolVersion() {
+        return HttpVersion.DEFAULT;
+    }
+
+    enum HttpVersion {
+        HTTP_1_1("http/1.1"),
+        HTTP_2("http/2.0"),
+        DEFAULT("default");
+
+        private final String value;
+
+        HttpVersion(String value) {
+            this.value = value;
+        }
+
+        public static HttpVersion from(String val) {
+            for (HttpVersion version : HttpVersion.values()) {
+                if (version.value.equals(val)) {
+                    return version;
+                }
+            }
+
+            return DEFAULT;
+        }
+
+    }
 }

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraClientCfg.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraClientCfg.java
@@ -39,9 +39,9 @@ public interface JiraClientCfg {
     }
 
     enum HttpVersion {
-        HTTP_1_1("http/1.1"),
-        HTTP_2("http/2.0"),
-        DEFAULT("default");
+        HTTP_1_1("HTTP/1.1"),
+        HTTP_2("HTTP/2.0"),
+        DEFAULT("DEFAULT");
 
         private final String value;
 
@@ -50,14 +50,19 @@ public interface JiraClientCfg {
         }
 
         public static HttpVersion from(String val) {
+            if (val == null || val.isBlank()) {
+                return DEFAULT;
+            }
+
+            var sanitizedVal = val.toUpperCase();
+
             for (HttpVersion version : HttpVersion.values()) {
-                if (version.value.equals(val)) {
+                if (version.value.equals(sanitizedVal)) {
                     return version;
                 }
             }
 
-            return DEFAULT;
+            throw new IllegalArgumentException("Unsupported HTTP version: " + val);
         }
-
     }
 }

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraHttpClient.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraHttpClient.java
@@ -1,0 +1,63 @@
+package com.walmartlabs.concord.plugins.jira;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public interface JiraHttpClient {
+    JiraHttpClient url(String url);
+
+    JiraHttpClient successCode(int successCode);
+
+    JiraHttpClient jiraAuth(String auth);
+
+    Map<String, Object> get() throws IOException;
+
+    Map<String, Object> post(Map<String, Object> data) throws IOException;
+
+    void post(File file) throws IOException;
+
+    void put(Map<String, Object> data) throws IOException;
+
+    void delete() throws IOException;
+
+    static void assertResponseCode(int code, String result, int successCode) {
+        if (code == successCode) {
+            return;
+        }
+
+        if (code == 400) {
+            throw new IllegalStateException("input is invalid (e.g. missing required fields, invalid values). Here are the full error details: " + result);
+        } else if (code == 401) {
+            throw new IllegalStateException("User is not authenticated. Here are the full error details: " + result);
+        } else if (code == 403) {
+            throw new IllegalStateException("User does not have permission to perform request. Here are the full error details: " + result);
+        } else if (code == 404) {
+            throw new IllegalStateException("Issue does not exist. Here are the full error details: " + result);
+        } else if (code == 500) {
+            throw new IllegalStateException("Internal Server Error. Here are the full error details" + result);
+        } else {
+            throw new IllegalStateException("Error: " + result);
+        }
+    }
+}

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraHttpClientFactory.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraHttpClientFactory.java
@@ -1,0 +1,50 @@
+package com.walmartlabs.concord.plugins.jira;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JiraHttpClientFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(JiraHttpClientFactory.class);
+
+    private JiraHttpClientFactory() {
+        throw new IllegalStateException("instantiation is not allowed");
+    }
+
+    public static JiraHttpClient create(JiraClientCfg cfg) {
+        try {
+            return new NativeJiraHttpClient(cfg);
+        } catch (NoClassDefFoundError e) {
+            // client2 may not exist
+            log.info("Falling back to okhttp client");
+        }
+
+        try {
+            return new JiraClient(cfg);
+        } catch (Exception e) {
+            // that's very unexpected as long as okhttp is still allowed
+            throw new IllegalStateException("No jira http client found");
+        }
+    }
+
+}

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraTaskCommon.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraTaskCommon.java
@@ -20,7 +20,6 @@ package com.walmartlabs.concord.plugins.jira;
  * =====
  */
 
-import com.squareup.okhttp.Credentials;
 import com.walmartlabs.concord.common.ConfigurationUtils;
 import com.walmartlabs.concord.sdk.MapUtils;
 import org.slf4j.Logger;
@@ -118,7 +117,7 @@ public class JiraTaskCommon {
     }
 
 
-    private Map<String, Object> createIssue(CreateIssueParams in) {
+    Map<String, Object> createIssue(CreateIssueParams in) {
         String projectKey = in.projectKey();
         String summary = in.summary();
         String description = in.description();
@@ -163,28 +162,20 @@ public class JiraTaskCommon {
                 objMain.put("assignee", assignee);
             }
 
-            if (customFieldsTypeKv != null && !customFieldsTypeKv.isEmpty()) {
-                for (Map.Entry<String, String> e : customFieldsTypeKv.entrySet()) {
-                    objMain.put(e.getKey(), String.valueOf(e.getValue()));
-                }
-            }
+            objMain.putAll(customFieldsTypeKv);
+            objMain.putAll(customFieldsTypeAtt);
 
-            if (customFieldsTypeAtt != null && !customFieldsTypeAtt.isEmpty()) {
-                for (Map.Entry<String, Object> e : customFieldsTypeAtt.entrySet()) {
-                    objMain.put(e.getKey(), e.getValue());
-                }
-            }
             Map<String, Object> objFields = Collections.singletonMap("fields", objMain);
 
             log.info("Creating new issue in '{}'...", projectKey);
 
-            Map<String, Object> results = new JiraClient(in)
+            Map<String, Object> results = getClient(in)
                     .url(in.jiraUrl() + "issue/")
                     .jiraAuth(buildAuth(in))
                     .successCode(201)
                     .post(objFields);
 
-            issueId = results.get("key").toString().replaceAll("\"", "");
+            issueId = results.get("key").toString().replace("\"", "");
             log.info("Issue #{} created in Project# '{}'", issueId, projectKey);
         } catch (Exception e) {
             throw new RuntimeException("Error occurred while creating an issue: " + e.getMessage(), e);
@@ -193,11 +184,11 @@ public class JiraTaskCommon {
         return Collections.singletonMap(JIRA_ISSUE_ID_KEY, issueId);
     }
 
-    private Map<String, Object> createSubTask(CreateSubTaskParams in) {
+    Map<String, Object> createSubTask(CreateSubTaskParams in) {
         return createIssue(in);
     }
 
-    private Map<String, Object> createComponent(CreateComponentParams in) {
+    Map<String, Object> createComponent(CreateComponentParams in) {
         String projectKey = in.projectKey();
         String componentName = in.componentName();
 
@@ -206,14 +197,14 @@ public class JiraTaskCommon {
             m.put("name", componentName);
             m.put("project", projectKey);
 
-            Map<String, Object> results = new JiraClient(in)
+            Map<String, Object> results = getClient(in)
                     .url(in.jiraUrl() + "component/")
                     .jiraAuth(buildAuth(in))
                     .successCode(201)
                     .post(m);
 
             String componentId = results.get("id").toString();
-            componentId = componentId.replaceAll("\"", "");
+            componentId = componentId.replace("\"", "");
             log.info("Component '{}' created successfully and its Id is '{}'", componentName, componentId);
             return Collections.singletonMap(JIRA_COMPONENT_ID_KEY, componentId);
         } catch (Exception e) {
@@ -221,11 +212,11 @@ public class JiraTaskCommon {
         }
     }
 
-    private void deleteComponent(DeleteComponentParams in) {
+    void deleteComponent(DeleteComponentParams in) {
         int componentId = in.componentId();
 
         try {
-            new JiraClient(in)
+            getClient(in)
                     .url(in.jiraUrl() + "component/" + componentId)
                     .jiraAuth(buildAuth(in))
                     .successCode(204)
@@ -237,7 +228,7 @@ public class JiraTaskCommon {
         }
     }
 
-    private void addAttachment(AddAttachmentParams in) {
+    void addAttachment(AddAttachmentParams in) {
         String issueKey = in.issueKey();
         String filePath = in.filePath();
 
@@ -247,7 +238,7 @@ public class JiraTaskCommon {
         }
 
         try {
-            new JiraClient(in)
+            getClient(in)
                     .url(in.jiraUrl() + "issue/" + issueKey + "/attachments")
                     .successCode(200)
                     .jiraAuth(buildAuth(in))
@@ -257,7 +248,7 @@ public class JiraTaskCommon {
         }
     }
 
-    private void addComment(AddCommentParams in) {
+    void addComment(AddCommentParams in) {
         String issueKey = in.issueKey();
         String comment = in.comment();
         boolean debug = in.debug();
@@ -265,7 +256,7 @@ public class JiraTaskCommon {
         try {
             Map<String, Object> m = Collections.singletonMap("body", comment);
 
-            new JiraClient(in)
+            getClient(in)
                     .url(in.jiraUrl() + "issue/" + issueKey + "/comment")
                     .jiraAuth(buildAuth(in))
                     .successCode(201)
@@ -281,7 +272,7 @@ public class JiraTaskCommon {
         }
     }
 
-    private void transition(TransitionParams in) {
+    void transition(TransitionParams in) {
         String issueKey = in.issueKey();
         String transitionId = Integer.toString(in.transitionId(-1));
         String transitionComment = in.transitionComment();
@@ -300,22 +291,13 @@ public class JiraTaskCommon {
             Map<String, Object> objupdate = Collections.singletonMap("update", objComment);
 
             Map<String, Object> objMain = new HashMap<>();
-            if (transitionFieldsTypeKv != null && !transitionFieldsTypeKv.isEmpty()) {
-                for (Map.Entry<String, String> e : transitionFieldsTypeKv.entrySet()) {
-                    objMain.put(e.getKey(), String.valueOf(e.getValue()));
-                }
-            }
-
-            if (transitionFieldsTypeAtt != null && !transitionFieldsTypeAtt.isEmpty()) {
-                for (Map.Entry<String, String> e : transitionFieldsTypeAtt.entrySet()) {
-                    objMain.put(e.getKey(), e.getValue());
-                }
-            }
+            transitionFieldsTypeKv.forEach((k, v) -> objMain.put(k, String.valueOf(v)));
+            objMain.putAll(transitionFieldsTypeAtt);
 
             Map<String, Object> objFields = Collections.singletonMap("fields", objMain);
             objupdate = ConfigurationUtils.deepMerge(objFields, ConfigurationUtils.deepMerge(objTransition, objupdate));
 
-            new JiraClient(in)
+            getClient(in)
                     .url(in.jiraUrl() + "issue/" + issueKey + "/transitions")
                     .jiraAuth(buildAuth(in))
                     .successCode(204)
@@ -327,11 +309,11 @@ public class JiraTaskCommon {
         }
     }
 
-    private void deleteIssue(DeleteIssueParams in) {
+    void deleteIssue(DeleteIssueParams in) {
         String issueKey = in.issueKey();
 
         try {
-            new JiraClient(in)
+            getClient(in)
                     .url(in.jiraUrl() + "issue/" + issueKey)
                     .jiraAuth(buildAuth(in))
                     .successCode(204)
@@ -343,18 +325,18 @@ public class JiraTaskCommon {
         }
     }
 
-    private void updateIssue(UpdateIssueParams in) {
+    void updateIssue(UpdateIssueParams in) {
         String issueKey = in.issueKey();
         Map<String, Object> fields = in.fields();
 
         log.info("Updating {} fields for issue #{}", fields, issueKey);
 
         try {
-            new JiraClient(in)
+            getClient(in)
                     .url(in.jiraUrl() + "issue/" + issueKey)
                     .jiraAuth(buildAuth(in))
                     .successCode(204)
-                    .put(Collections.singletonMap("fields", fields));
+                    .put(Map.of("fields", fields));
 
             log.info("Issue #{} updated successfully.", issueKey);
         } catch (Exception e) {
@@ -363,7 +345,7 @@ public class JiraTaskCommon {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, Object> getIssues(GetIssuesParams in) {
+    Map<String, Object> getIssues(GetIssuesParams in) {
         String projectKey = in.projectKey();
         String issueType = in.issueType();
         String issueStatus = in.issueStatus();
@@ -389,7 +371,7 @@ public class JiraTaskCommon {
                 List<String> fieldList = Collections.singletonList("key");
                 objMain.put("fields", fieldList);
 
-                Map<String, Object> results = new JiraClient(in)
+                Map<String, Object> results = getClient(in)
                         .url(in.jiraUrl() + "search")
                         .jiraAuth(buildAuth(in))
                         .successCode(200)
@@ -423,7 +405,7 @@ public class JiraTaskCommon {
 
     private String buildAuth(TaskParams in) {
         JiraCredentials c = credentials(in);
-        return Credentials.basic(c.username(), c.password());
+        return c.authHeaderValue();
     }
 
     private JiraCredentials credentials(TaskParams in) {
@@ -453,7 +435,7 @@ public class JiraTaskCommon {
         String password = MapUtils.getString(input, JIRA_PASSWORD_KEY);
 
         try {
-            return secretService.exportCredentials(org, secretName, password);
+            return getSecretService().exportCredentials(org, secretName, password);
         } catch (Exception e) {
              throw new RuntimeException("Error export credentials: " + e.getMessage());
         }
@@ -461,7 +443,7 @@ public class JiraTaskCommon {
 
     private Map<String, Object> currentStatus(CurrentStatusParams in) {
         try {
-            Map<String, Object> results = new JiraClient(in)
+            Map<String, Object> results = getClient(in)
                     .url(formatUrl(in.jiraUrl()) + "issue/" + in.issueKey() + "?fields=status")
                     .jiraAuth(buildAuth(in))
                     .successCode(200)
@@ -506,6 +488,14 @@ public class JiraTaskCommon {
             }
         }
         return jqlQuery;
+    }
+
+    JiraHttpClient getClient(TaskParams in) {
+        return JiraHttpClientFactory.create(in);
+    }
+
+    JiraSecretService getSecretService() {
+        return secretService;
     }
 
 }

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraTaskCommon.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/JiraTaskCommon.java
@@ -491,7 +491,27 @@ public class JiraTaskCommon {
     }
 
     JiraHttpClient getClient(TaskParams in) {
-        return JiraHttpClientFactory.create(in);
+        try {
+            return getNativeClient(in);
+        } catch (NoClassDefFoundError e) {
+            // client2 may not exist
+            log.info("Falling back to okhttp client");
+        }
+
+        try {
+            return getOkHttpClient(in);
+        } catch (Exception | NoClassDefFoundError e) {
+            // that's very unexpected as long as okhttp is still allowed
+            throw new IllegalStateException("No jira http client found");
+        }
+    }
+
+    JiraHttpClient getNativeClient(TaskParams in) {
+        return new NativeJiraHttpClient(in);
+    }
+
+    JiraHttpClient getOkHttpClient(TaskParams in) {
+        return new JiraClient(in);
     }
 
     JiraSecretService getSecretService() {

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/NativeJiraHttpClient.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/NativeJiraHttpClient.java
@@ -1,0 +1,178 @@
+package com.walmartlabs.concord.plugins.jira;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.walmartlabs.concord.client2.impl.MultipartBuilder;
+import com.walmartlabs.concord.client2.impl.MultipartRequestBodyHandler;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NativeJiraHttpClient implements JiraHttpClient {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module());
+    static final JavaType MAP_TYPE = MAPPER.getTypeFactory()
+            .constructMapType(HashMap.class, String.class, Object.class);
+    private static final JavaType LIST_OF_MAPS_TYPE = MAPPER.getTypeFactory()
+            .constructCollectionType(List.class, MAP_TYPE);
+    private static final String CONTENT_TYPE = "Content-Type";
+
+    private final HttpClient client;
+    private final JiraClientCfg cfg;
+    private URI url;
+    private int successCode;
+    private String auth;
+
+    public NativeJiraHttpClient(JiraClientCfg cfg) {
+        this.cfg = cfg;
+
+        var builder = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(cfg.connectTimeout()));
+
+        if (cfg.httpProtocolVersion() != JiraClientCfg.HttpVersion.DEFAULT) {
+            if (cfg.httpProtocolVersion() == JiraClientCfg.HttpVersion.HTTP_2) {
+                builder.version(HttpClient.Version.HTTP_2);
+            } else if (cfg.httpProtocolVersion() == JiraClientCfg.HttpVersion.HTTP_1_1) {
+                builder.version(HttpClient.Version.HTTP_1_1);
+            }
+        }
+
+        client = builder.build();
+    }
+
+    @Override
+    public JiraHttpClient url(String url) {
+        this.url = URI.create(url);
+        return this;
+    }
+
+    @Override
+    public JiraHttpClient successCode(int successCode) {
+        this.successCode = successCode;
+        return this;
+    }
+
+    @Override
+    public JiraHttpClient jiraAuth(String auth) {
+        this.auth = auth;
+        return this;
+    }
+
+    @Override
+    public Map<String, Object> get() throws IOException {
+        HttpRequest request = requestBuilder(auth)
+                .uri(url)
+                .GET()
+                .build();
+
+        return call(request, MAP_TYPE);
+    }
+
+    @Override
+    public Map<String, Object> post(Map<String, Object> data) throws IOException {
+        HttpRequest.BodyPublisher body = HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(data));
+        HttpRequest request = requestBuilder(auth)
+                .uri(url)
+                .POST(body)
+                .header(CONTENT_TYPE, "application/json; charset=utf-8")
+                .build();
+
+        return call(request, MAP_TYPE);
+    }
+
+    @Override
+    public void post(File file) throws IOException {
+        var requestBody = new MultipartBuilder(Constants.BOUNDARY)
+                .addFormDataPart("file", file.getName(), new MultipartRequestBodyHandler.PathRequestBody(file.toPath()))
+                .build();
+
+        try (InputStream body = requestBody.getContent()) {
+            var req = requestBuilder(auth)
+                    .uri(url)
+                    .POST(HttpRequest.BodyPublishers.ofInputStream(() -> body))
+                    .header(CONTENT_TYPE, requestBody.contentType().toString())
+                    .header("X-Atlassian-Token", "nocheck")
+                    .build();
+
+            call(req, LIST_OF_MAPS_TYPE);
+        }
+    }
+
+    @Override
+    public void put(Map<String, Object> data) throws IOException {
+        HttpRequest request = requestBuilder(auth)
+                .uri(url)
+                .PUT(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(data)))
+                .header(CONTENT_TYPE, "application/json; charset=utf-8")
+                .build();
+
+        call(request, MAP_TYPE);
+    }
+
+    @Override
+    public void delete() throws IOException {
+        HttpRequest request = requestBuilder(auth)
+                .uri(url)
+                .DELETE()
+                .build();
+
+        call(request, MAP_TYPE);
+    }
+
+    private HttpRequest.Builder requestBuilder(String auth) {
+        return HttpRequest.newBuilder()
+                .timeout(Duration.ofSeconds(cfg.readTimeout()))
+                .header("Authorization", auth)
+                .header("Accept", "application/json");
+    }
+
+    <T> T call(HttpRequest request, JavaType returnType) throws IOException {
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            int statusCode = response.statusCode();
+            String results = response.body();
+            JiraHttpClient.assertResponseCode(statusCode, results, successCode);
+
+            if (results == null || statusCode == 204) {
+                return null;
+            } else {
+                return MAPPER.readValue(results, returnType);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/TaskParams.java
+++ b/tasks/jira/src/main/java/com/walmartlabs/concord/plugins/jira/TaskParams.java
@@ -23,6 +23,7 @@ package com.walmartlabs.concord.plugins.jira;
 import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
 import com.walmartlabs.concord.runtime.v2.sdk.Variables;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 
 public class TaskParams implements JiraClientCfg {
@@ -75,6 +76,7 @@ public class TaskParams implements JiraClientCfg {
     private static final String JIRA_AUTH_KEY = "auth";
     private static final String JIRA_USER_ID_KEY = "userId";
     private static final String JIRA_PASSWORD_KEY = "password";
+    private static final String JIRA_HTTP_CLIENT_PROTOCOL_VERSION_KEY = "httpClientProtocolVersion";
     private static final String CLIENT_CONNECTTIMEOUT = "connectTimeout";
     private static final String CLIENT_READTIMEOUT = "readTimeout";
     private static final String CLIENT_WRITETIMEOUT = "writeTimeout";
@@ -90,7 +92,7 @@ public class TaskParams implements JiraClientCfg {
         try {
             return Action.valueOf(action.trim().toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new RuntimeException("Unknown action: '" + action + "'. Available actions: " + Arrays.toString(Action.values()));
+            throw new IllegalArgumentException("Unknown action: '" + action + "'. Available actions: " + Arrays.toString(Action.values()));
         }
     }
 
@@ -123,6 +125,13 @@ public class TaskParams implements JiraClientCfg {
 
     public String pwd() {
         return variables.assertString(JIRA_PASSWORD_KEY);
+    }
+
+    @Override
+    public HttpVersion httpProtocolVersion() {
+        return Optional.ofNullable(variables.getString(JIRA_HTTP_CLIENT_PROTOCOL_VERSION_KEY))
+                .map(HttpVersion::from)
+                .orElse(JiraClientCfg.super.httpProtocolVersion());
     }
 
     public static class CreateIssueParams extends TaskParams {
@@ -178,12 +187,12 @@ public class TaskParams implements JiraClientCfg {
             return variables.getList(JIRA_ISSUE_COMPONENTS_KEY, null);
         }
 
-        public Map<String, String> customFieldsTypeKv() {
-            return variables.getMap(JIRA_CUSTOM_FIELDS_KV_KEY, null);
+        public @Nonnull Map<String, String> customFieldsTypeKv() {
+            return variables.getMap(JIRA_CUSTOM_FIELDS_KV_KEY, Map.of());
         }
 
-        public Map<String, Object> customFieldsTypeAtt() {
-            return variables.getMap(JIRA_CUSTOM_FIELDS_ATTR_KEY, Collections.emptyMap());
+        public @Nonnull Map<String, Object> customFieldsTypeAtt() {
+            return variables.getMap(JIRA_CUSTOM_FIELDS_ATTR_KEY, Map.of());
         }
     }
 
@@ -283,12 +292,12 @@ public class TaskParams implements JiraClientCfg {
             return variables.assertString(JIRA_TRANSITION_COMMENT_KEY);
         }
 
-        public Map<String, String> transitionFieldsTypeKv() {
-            return variables.getMap(JIRA_CUSTOM_FIELDS_KV_KEY, null);
+        public @Nonnull Map<String, String> transitionFieldsTypeKv() {
+            return variables.getMap(JIRA_CUSTOM_FIELDS_KV_KEY, Map.of());
         }
 
-        public Map<String, String> transitionFieldsTypeAtt() {
-            return variables.getMap(JIRA_CUSTOM_FIELDS_ATTR_KEY, null);
+        public @Nonnull Map<String, String> transitionFieldsTypeAtt() {
+            return variables.getMap(JIRA_CUSTOM_FIELDS_ATTR_KEY, Map.of());
         }
     }
 
@@ -341,7 +350,7 @@ public class TaskParams implements JiraClientCfg {
         }
 
         @Override
-        public Map<String, Object> customFieldsTypeAtt() {
+        public @Nonnull Map<String, Object> customFieldsTypeAtt() {
             Map<String, Object> customFieldsTypeAtt = new HashMap<>(super.customFieldsTypeAtt());
             customFieldsTypeAtt.put("parent", Collections.singletonMap("key", parentKey()));
 

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/AbstractWiremockTest.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/AbstractWiremockTest.java
@@ -1,0 +1,264 @@
+package com.walmartlabs.concord.plugins.jira;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class AbstractWiremockTest {
+
+    @RegisterExtension
+    static WireMockExtension rule = WireMockExtension.newInstance()
+            .options(wireMockConfig()
+                    .dynamicPort()
+                    .notifier(new ConsoleNotifier(true)))
+            .build();
+
+    protected static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new Jdk8Module());
+
+    protected JiraClientCfg jiraClientCfg;
+
+    protected void stubForCurrentStatus() {
+        var body = Map.of(
+                "fields", Map.of(
+                        "status", Map.of(
+                                "name", "Open"
+                        )
+                )
+        );
+
+        var mapper = new ObjectMapper();
+
+        try {
+            rule.stubFor(get(urlEqualTo("/issue/issueId?fields=status"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(mapper.writeValueAsString(body)))
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Invalid json: " + e.getMessage());
+        }
+    }
+
+    protected void stubForBasicAuth() {
+        rule.stubFor(post(urlEqualTo("/issue/"))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\n" +
+                                "  \"id\": \"123\",\n" +
+                                "  \"key\": \"key1\",\n" +
+                                "  \"self\": \"2\"\n" +
+                                "}\n"))
+        );
+    }
+
+    protected void stubForAddAttachment() {
+        rule.stubFor(post(urlEqualTo("/issue/issueId/attachments"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[{\n" +
+                                "  \"id\": \"123\",\n" +
+                                "  \"key\": \"key1\",\n" +
+                                "  \"self\": \"2\"\n" +
+                                "}]"))
+        );
+    }
+
+    protected void stubForPut() {
+        rule.stubFor(put(urlEqualTo("/issue/issueId"))
+                .willReturn(aResponse()
+                        .withStatus(204))
+        );
+    }
+
+    protected void stubForDelete() {
+        rule.stubFor(delete(urlEqualTo("/issue/issueId"))
+                .willReturn(aResponse()
+                        .withStatus(204))
+        );
+    }
+
+    private static void assertAuth(String value) {
+        assertEquals("Basic " + Base64.getEncoder().encodeToString("mock-user:mock-pass".getBytes(StandardCharsets.UTF_8)), value);
+    }
+
+    @BeforeEach
+    void setUp() {
+        jiraClientCfg = new JiraClientCfg() {
+            @Override
+            public HttpVersion httpProtocolVersion() {
+                return HttpVersion.HTTP_1_1;
+            }
+        };
+    }
+
+    abstract JiraHttpClient getClient(JiraClientCfg cfg);
+
+    @Test
+    void testGet() throws IOException {
+        stubForCurrentStatus();
+
+        Map<String, Object> resp = getClient(jiraClientCfg)
+                .url(rule.baseUrl() + "/issue/issueId?fields=status")
+                .jiraAuth(new JiraCredentials("mock-user", "mock-pass").authHeaderValue())
+                .successCode(200)
+                .get();
+
+        assertNotNull(resp);
+        Map<String, Object> expected = Map.of(
+                "fields", Map.of(
+                        "status", Map.of(
+                                "name", "Open"
+                        )
+                )
+        );
+        assertEquals(expected, resp);
+
+        ServeEvent event = rule.getAllServeEvents().get(0);
+        assertNotNull(event);
+
+        assertAuth(event.getRequest().header("Authorization").firstValue());
+    }
+
+    @Test
+    void testPost() throws IOException {
+        stubForBasicAuth();
+
+        Map<String, Object> resp = getClient(jiraClientCfg)
+                .url(rule.baseUrl() + "/issue/")
+                .jiraAuth(new JiraCredentials("mock-user", "mock-pass").authHeaderValue())
+                .successCode(201)
+                .post(Map.of("field1", "value1"));
+
+        assertNotNull(resp);
+        assertEquals("123", resp.get("id"));
+
+        ServeEvent event = rule.getAllServeEvents().get(0);
+        assertNotNull(event);
+
+        Map<String, Object> requestBody = objectMapper.readValue(event.getRequest().getBody(), NativeJiraHttpClient.MAP_TYPE);
+        assertEquals("value1", requestBody.get("field1"));
+
+        assertAuth(event.getRequest().header("Authorization").firstValue());
+    }
+
+    @Test
+    void testPostFile() throws IOException {
+        stubForAddAttachment();
+
+        getClient(jiraClientCfg)
+                .url(rule.baseUrl() + "/issue/issueId/attachments")
+                .successCode(200)
+                .jiraAuth(new JiraCredentials("mock-user", "mock-pass").authHeaderValue())
+                .post(Paths.get("src/test/resources/sample.txt").toFile());
+
+        ServeEvent event = rule.getAllServeEvents().get(0);
+        assertNotNull(event);
+
+        String requestBody = event.getRequest().getBodyAsString();
+        assertTrue(requestBody.contains("Content-Length: 11"));
+        assertTrue(requestBody.contains("Content-Type: application/octet-stream"));
+        assertTrue(requestBody.contains("Content-Disposition: form-data; name=\"file\"; filename=\"sample.txt\""));
+
+        String contentType = event.getRequest().header("Content-Type").firstValue();
+        assertEquals("multipart/form-data; boundary=" + Constants.BOUNDARY, contentType);
+
+        assertAuth(event.getRequest().header("Authorization").firstValue());
+    }
+
+    @Test
+    void testPut() throws IOException {
+        stubForPut();
+
+        getClient(jiraClientCfg)
+                .url(rule.baseUrl() + "/issue/issueId")
+                .successCode(204)
+                .jiraAuth(new JiraCredentials("mock-user", "mock-pass").authHeaderValue())
+                .put(Map.of("aKey", "aValue"));
+
+        ServeEvent event = rule.getAllServeEvents().get(0);
+        assertNotNull(event);
+
+        assertAuth(event.getRequest().header("Authorization").firstValue());
+    }
+
+    @Test
+    void testDelete() throws IOException {
+        stubForDelete();
+
+        getClient(jiraClientCfg)
+                .url(rule.baseUrl() + "/issue/issueId")
+                .successCode(204)
+                .jiraAuth(new JiraCredentials("mock-user", "mock-pass").authHeaderValue())
+                .delete();
+
+        ServeEvent event = rule.getAllServeEvents().get(0);
+        assertNotNull(event);
+
+        assertAuth(event.getRequest().header("Authorization").firstValue());
+    }
+
+    @Test
+    void testResponseCodes() {
+        var ex400 = assertThrows(IllegalStateException.class, () -> JiraHttpClient.assertResponseCode(400, "example message", 200));
+        assertTrue(ex400.getMessage().contains("input is invalid"));
+        var ex401 = assertThrows(IllegalStateException.class, () -> JiraHttpClient.assertResponseCode(401, "example message", 200));
+        assertTrue(ex401.getMessage().contains("User is not authenticated"));
+        var ex403 = assertThrows(IllegalStateException.class, () -> JiraHttpClient.assertResponseCode(403, "example message", 200));
+        assertTrue(ex403.getMessage().contains("User does not have permission to perform request"));
+        var ex404 = assertThrows(IllegalStateException.class, () -> JiraHttpClient.assertResponseCode(404, "example message", 200));
+        assertTrue(ex404.getMessage().contains("Issue does not exist"));
+        var ex500 = assertThrows(IllegalStateException.class, () -> JiraHttpClient.assertResponseCode(500, "example message", 200));
+        assertTrue(ex500.getMessage().contains("Internal Server Error"));
+        var exUnknown = assertThrows(IllegalStateException.class, () -> JiraHttpClient.assertResponseCode(501, "example message", 200));
+        assertTrue(exUnknown.getMessage().contains("Error: example message"));
+    }
+
+}

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/CommonClientLoaderTest.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/CommonClientLoaderTest.java
@@ -1,0 +1,82 @@
+package com.walmartlabs.concord.plugins.jira;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class CommonClientLoaderTest {
+
+    @Mock
+    JiraSecretService jiraSecretService;
+
+    @Spy
+    JiraTaskCommon delegate = new JiraTaskCommon(jiraSecretService);
+
+    @Test
+    void testLoadClient() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("action", "getIssues");
+
+        var client = delegate.getClient(TaskParams.of(new MapBackedVariables(input), Map.of()));
+
+        assertInstanceOf(NativeJiraHttpClient.class, client);
+    }
+
+    @Test
+    void testLoadClientFallback() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("action", "getIssues");
+
+        doThrow(new NoClassDefFoundError()).when(delegate).getNativeClient(any());
+
+        var client = delegate.getClient(TaskParams.of(new MapBackedVariables(input), Map.of()));
+        assertInstanceOf(JiraClient.class, client);
+    }
+
+    @Test
+    void testNoClient() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("action", "getIssues");
+
+        doThrow(new NoClassDefFoundError()).when(delegate).getNativeClient(any());
+        doThrow(new NoClassDefFoundError()).when(delegate).getOkHttpClient(any());
+
+        var params = TaskParams.of(new MapBackedVariables(input), Map.of());
+
+        var expected = assertThrows(IllegalStateException.class, () -> delegate.getClient(params));
+        assertTrue(expected.getMessage().contains("No jira http client found"));
+    }
+}

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/CommonTest.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/CommonTest.java
@@ -1,0 +1,316 @@
+package com.walmartlabs.concord.plugins.jira;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommonTest {
+
+    @Mock
+    JiraClient jiraClient;
+
+    @Mock
+    JiraSecretService jiraSecretService;
+
+    @Spy
+    JiraTaskCommon delegate = new JiraTaskCommon(jiraSecretService);
+
+    Map<String, Object> input;
+    Map<String, Object> defaults;
+
+    @BeforeEach
+    public void setup() {
+        input = new HashMap<>();
+        defaults = new HashMap<>();
+        defaults.put("apiUrl", "https://localhost:1234/");
+        defaults.put(
+                "auth", Map.of(
+                        "basic", Map.of(
+                                "username", "user",
+                                "password", "pass"
+                            )
+                )
+        );
+
+        when(jiraClient.jiraAuth(any())).thenReturn(jiraClient);
+        when(jiraClient.url(anyString())).thenReturn(jiraClient);
+        when(jiraClient.successCode(anyInt())).thenReturn(jiraClient);
+
+        doAnswer(invocation -> jiraClient).when(delegate).getClient(any());
+    }
+
+    @Test
+    void testCreateIssueWithBasicAuth() throws Exception {
+        input.put("action", "createIssue");
+        input.put("projectKey", "mock-proj-key");
+        input.put("summary", "mock-summary");
+        input.put("description", "mock-description");
+        input.put("requestorUid", "mock-uid");
+        input.put("issueType", "bug");
+
+        when(jiraClient.post(anyMap())).thenReturn(Map.of("key", "\"result-key\""));
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+        assertNotNull(result);
+        assertEquals("result-key", result.get("issueId"));
+
+        verify(jiraSecretService, times(0))
+                .exportCredentials("organization", "secret", null);
+
+        verify(delegate, times(1)).createIssue(any());
+    }
+
+    @Test
+    void testCreateIssueWithSecret() throws Exception {
+        input.put("action", "createIssue");
+        input.put("projectKey", "mock-proj-key");
+        input.put("summary", "mock-summary");
+        input.put("description", "mock-description");
+        input.put("requestorUid", "mock-uid");
+        input.put("issueType", "bug");
+        input.put("auth", Map.of(
+                "secret", Map.of(
+                        "org", "organization",
+                        "name", "secret"
+                )
+        ));
+
+        when(jiraSecretService.exportCredentials(any(), any(), any())).thenReturn(new JiraCredentials("user", "pwd"));
+        when(jiraClient.post(anyMap())).thenReturn(Map.of("key", "\"result-key\""));
+        doAnswer(invocation -> jiraSecretService).when(delegate).getSecretService();
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+        assertNotNull(result);
+        assertEquals("result-key", result.get("issueId"));
+
+        verify(jiraSecretService, times(1))
+                .exportCredentials("organization", "secret", null);
+        verify(delegate, times(1)).createIssue(any());
+        verify(delegate, times(1)).getSecretService();
+    }
+
+    @Test
+    void testAddComment() throws IOException {
+        input.put("action", "addComment");
+        input.put("issueKey", "mock-issue");
+        input.put("comment", "mock-comment");
+
+        when(jiraClient.post(Mockito.anyMap())).thenReturn(null);
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(delegate, times(1)).addComment(any());
+    }
+
+    @Test
+    void testAddAttachment() throws IOException {
+        input.put("action", "addAttachment");
+        input.put("issueKey", "issueId");
+        input.put("userId", "userId");
+        input.put("password", "password");
+        input.put("filePath", "src/test/resources/sample.txt");
+
+        doNothing().when(jiraClient).post(Mockito.any(File.class));
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertTrue(result.isEmpty());
+
+        verify(delegate, times(1)).addAttachment(any());
+    }
+
+    @Test
+    void testCreateComponent() throws IOException {
+        input.put("action", "createComponent");
+        input.put("projectKey", "mock-project");
+        input.put("componentName", "mock-component");
+
+        when(jiraClient.post(Mockito.anyMap())).thenReturn(Map.of("id", "\"321\""));
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertNotNull(result);
+        assertEquals("321", result.get("componentId"));
+
+        verify(delegate, times(1)).createComponent(any());
+    }
+
+    @Test
+    void testDeleteComponent() throws IOException {
+        input.put("action", "deleteComponent");
+        input.put("componentId", 321);
+
+        doNothing().when(jiraClient).delete();
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(delegate, times(1)).deleteComponent(any());
+    }
+
+    @Test
+    void testTransition() throws IOException {
+        input.put("action", "transition");
+        input.put("issueKey", "issue-123");
+        input.put("transitionId", 543);
+        input.put("transitionComment", "mock-transition-comment");
+
+        when(jiraClient.post(Mockito.anyMap())).thenReturn(null);
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(delegate, times(1)).transition(any());
+    }
+
+    @Test
+    void testDeleteIssue() throws IOException {
+        input.put("action", "deleteIssue");
+        input.put("issueKey", "issue-123");
+
+        doNothing().when(jiraClient).delete();
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(delegate, times(1)).deleteIssue(any());
+    }
+
+    @Test
+    void testUpdateIssue() throws IOException {
+        input.put("action", "updateIssue");
+        input.put("issueKey", "issue-123");
+        input.put("fields", Map.of("field1", "value1", "field2", "value2"));
+
+        doNothing().when(jiraClient).put(anyMap());
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(delegate, times(1)).updateIssue(any());
+    }
+
+    @Test
+    void testCreateSubTask() throws IOException {
+        input.put("action", "createSubTask");
+        input.put("parentIssueKey", "parent-issue-123");
+        input.put("projectKey", "mock-proj-key");
+        input.put("summary", "mock-summary");
+        input.put("description", "mock-description");
+        input.put("requestorUid", "mock-uid");
+        input.put("issueType", "bug");
+
+        when(jiraClient.post(anyMap())).thenReturn(Map.of("key", "\"result-key\""));
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        assertNotNull(result);
+        assertEquals("result-key", result.get("issueId"));
+
+        verify(delegate, times(1)).createSubTask(any());
+    }
+
+    @Test
+    void testCurrentStatus() throws IOException {
+        input.put("action", "currentStatus");
+        input.put("issueKey", "issueId");
+
+        when(jiraClient.get()).thenReturn(Map.of(
+                "fields", Map.of(
+                        "status", Map.of(
+                                "name", "Open"
+                        )
+                )
+        ));
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+
+        var status = assertInstanceOf(String.class, result.get("issueStatus"));
+        assertNotNull(status);
+        assertEquals("Open", status);
+    }
+
+    @Test
+    void testGetIssues() throws IOException {
+        input.put("action", "getIssues");
+        input.put("projectKey", "mock-proj-key");
+        input.put("summary", "mock-summary");
+        input.put("description", "mock-description");
+        input.put("requestorUid", "mock-uid");
+        input.put("issueType", "bug");
+
+        when(jiraClient.post(anyMap())).thenReturn(Map.of(
+                "issues", List.of(
+                        Map.of(
+                                "id", "123"
+                        )
+                )
+        ));
+
+        var result = delegate.execute(TaskParams.of(new MapBackedVariables(input), defaults));
+        assertNotNull(result);
+        assertEquals(1, result.get("issueCount"));
+
+        var issues = assertInstanceOf(List.class, result.get("issueList"));
+        assertEquals(1, issues.size());
+
+        verify(delegate, times(1)).getIssues(any());
+    }
+}

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/JiraClientTest.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/JiraClientTest.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.plugins.jira;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc., Concord Authors
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,11 @@ package com.walmartlabs.concord.plugins.jira;
  * =====
  */
 
-import java.util.Base64;
+class JiraClientTest extends AbstractWiremockTest {
 
-public class JiraCredentials {
-
-    private final String username;
-    private final String password;
-
-    public JiraCredentials(String username, String password) {
-        this.username = username;
-        this.password = password;
+    @Override
+    JiraHttpClient getClient(JiraClientCfg cfg) {
+        return new JiraClient(cfg);
     }
 
-    public String username() {
-        return username;
-    }
-
-    public String password() {
-        return password;
-    }
-
-    public String authHeaderValue() {
-        return "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
-    }
 }

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/NativeJiraHttpClientTest.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/NativeJiraHttpClientTest.java
@@ -4,7 +4,7 @@ package com.walmartlabs.concord.plugins.jira;
  * *****
  * Concord
  * -----
- * Copyright (C) 2017 - 2020 Walmart Inc., Concord Authors
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
  * -----
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,27 +20,11 @@ package com.walmartlabs.concord.plugins.jira;
  * =====
  */
 
-import java.util.Base64;
+class NativeJiraHttpClientTest extends AbstractWiremockTest {
 
-public class JiraCredentials {
-
-    private final String username;
-    private final String password;
-
-    public JiraCredentials(String username, String password) {
-        this.username = username;
-        this.password = password;
+    @Override
+    JiraHttpClient getClient(JiraClientCfg cfg) {
+        return new NativeJiraHttpClient(cfg);
     }
 
-    public String username() {
-        return username;
-    }
-
-    public String password() {
-        return password;
-    }
-
-    public String authHeaderValue() {
-        return "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
-    }
 }

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/TaskParamsTest.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/TaskParamsTest.java
@@ -1,0 +1,63 @@
+package com.walmartlabs.concord.plugins.jira;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TaskParamsTest {
+
+    @Test
+    void testHttpVersionDefault() {
+        Map<String, Object> input = Map.of();
+        var params = new TaskParams.DeleteIssueParams(new MapBackedVariables(input));
+
+        assertEquals(JiraClientCfg.HttpVersion.DEFAULT, params.httpProtocolVersion());
+    }
+
+    @Test
+    void testHttpVersion1() {
+        Map<String, Object> input = Map.of("httpClientProtocolVersion", "http/1.1");
+        var params = new TaskParams.DeleteIssueParams(new MapBackedVariables(input));
+
+        assertEquals(JiraClientCfg.HttpVersion.HTTP_1_1, params.httpProtocolVersion());
+    }
+
+    @Test
+    void testHttpVersion2() {
+        Map<String, Object> input = Map.of("httpClientProtocolVersion", "http/2.0");
+        var params = new TaskParams.DeleteIssueParams(new MapBackedVariables(input));
+
+        assertEquals(JiraClientCfg.HttpVersion.HTTP_2, params.httpProtocolVersion());
+    }
+
+    @Test
+    void testHttpVersionUnknown() {
+        Map<String, Object> input = Map.of("httpClientProtocolVersion", "invalidValue");
+        var params = new TaskParams.DeleteIssueParams(new MapBackedVariables(input));
+
+        assertEquals(JiraClientCfg.HttpVersion.DEFAULT, params.httpProtocolVersion());
+    }
+}

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/TaskParamsTest.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/TaskParamsTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaskParamsTest {
 
@@ -54,10 +56,19 @@ class TaskParamsTest {
     }
 
     @Test
+    void testHttpVersionBlank() {
+        Map<String, Object> input = Map.of("httpClientProtocolVersion", " ");
+        var params = new TaskParams.DeleteIssueParams(new MapBackedVariables(input));
+
+        assertEquals(JiraClientCfg.HttpVersion.DEFAULT, params.httpProtocolVersion());
+    }
+
+    @Test
     void testHttpVersionUnknown() {
         Map<String, Object> input = Map.of("httpClientProtocolVersion", "invalidValue");
         var params = new TaskParams.DeleteIssueParams(new MapBackedVariables(input));
 
-        assertEquals(JiraClientCfg.HttpVersion.DEFAULT, params.httpProtocolVersion());
+        var expected = assertThrows(IllegalArgumentException.class, params::httpProtocolVersion);
+        assertTrue(expected.getMessage().contains("Unsupported HTTP version"));
     }
 }

--- a/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/v2/JiraTaskV2Test.java
+++ b/tasks/jira/src/test/java/com/walmartlabs/concord/plugins/jira/v2/JiraTaskV2Test.java
@@ -1,0 +1,102 @@
+package com.walmartlabs.concord.plugins.jira.v2;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.plugins.jira.JiraTaskCommon;
+import com.walmartlabs.concord.plugins.jira.TaskParams;
+import com.walmartlabs.concord.runtime.v2.sdk.Context;
+import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
+import com.walmartlabs.concord.runtime.v2.sdk.SecretService;
+import com.walmartlabs.concord.runtime.v2.sdk.TaskResult;
+import com.walmartlabs.concord.runtime.v2.sdk.Variables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JiraTaskV2Test {
+
+    @Mock
+    private Context context;
+
+    @Mock
+    SecretService secretService;
+
+    @Mock
+    private JiraTaskCommon common;
+
+    private JiraTaskV2 task;
+    private Map<String, Object> input;
+    private Variables defaultVariables;
+
+    @BeforeEach
+    public void setup() {
+        task = spy(new JiraTaskV2(context));
+        input = new HashMap<>();
+        defaultVariables = new MapBackedVariables(Map.of());
+    }
+
+    @Test
+    void testExecute() {
+        input.put("action", "deleteIssue");
+        when(task.getDelegate()).thenReturn(common);
+        when(context.defaultVariables()).thenReturn(defaultVariables);
+        when(common.execute(any(TaskParams.DeleteIssueParams.class))).thenReturn(Map.of("customResult", "customResultValue"));
+
+        var result = assertDoesNotThrow(() -> task.execute(new MapBackedVariables(input)));
+        var simpleResult = assertInstanceOf(TaskResult.SimpleResult.class, result);
+
+        assertTrue(simpleResult.ok());
+        assertEquals("customResultValue", simpleResult.values().get("customResult"));
+    }
+
+    @Test
+    void testSecretService() throws Exception {
+        when(secretService.exportCredentials(anyString(), anyString(), nullable(String.class)))
+                .thenReturn(SecretService.UsernamePassword.of("foo", "bar"));
+
+        var v2SecretService = new JiraTaskV2.V2SecretService(secretService);
+
+        var creds = v2SecretService.exportCredentials("org", "name", null);
+
+        assertEquals("foo", creds.username());
+        assertEquals("bar", creds.password());
+
+        verify(secretService, times(1)).exportCredentials(anyString(), anyString(), nullable(String.class));
+    }
+}


### PR DESCRIPTION
* not sure why unit tests were disabled, but now they back and improved
* add new jira http client using native `HttpClient`
  * leverages concord-client2 for `POST multipart/form-data` call
  * falls back to okhttp for now, until 2.10.0+ is more widespread
* Remove Gson dependency in favor of provided jackson