### PR TITLE
terraform: remove okhttp dependency

### DIFF
--- a/tasks/terraform/pom.xml
+++ b/tasks/terraform/pom.xml
@@ -95,12 +95,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>2.7.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.walmartlabs.concord.runtime.v2</groupId>
             <artifactId>concord-runner-v2</artifactId>
             <version>${concord.version}</version>

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskIT.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskIT.java
@@ -51,12 +51,12 @@ public class TerraformTaskIT {
     private static final String CURRENT_VERSION = getCurrentVersion();
 
     @Test
-    public void testWithRuntimeV1() throws Exception {
+    void testWithRuntimeV1() throws Exception {
         test("runtimeV1/concord.yml");
     }
 
     @Test
-    public void testWithRuntimeV2() throws Exception {
+    void testWithRuntimeV2() throws Exception {
         test("runtimeV2/concord.yml");
     }
 

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2Test.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2Test.java
@@ -20,7 +20,6 @@ package com.walmartlabs.concord.plugins.terraform;
  * =====
  */
 
-import com.squareup.okhttp.OkHttpClient;
 import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.client.ApiClientConfiguration;
 import com.walmartlabs.concord.client.ApiClientFactory;
@@ -234,7 +233,7 @@ class TerraformTaskV2Test extends AbstractTerraformTest {
 
     ApiClientFactory getApiClientFactory() {
         return cfg -> {
-            ApiClient apiClient = new ConcordApiClient(cfg.baseUrl(), new OkHttpClient());
+            ApiClient apiClient = new ConcordApiClient(cfg.baseUrl());
             apiClient.setReadTimeout(60000);
             apiClient.setConnectTimeout(10000);
             apiClient.setWriteTimeout(60000);

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2Test.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskV2Test.java
@@ -36,7 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -71,7 +70,7 @@ import static org.mockito.Mockito.*;
 // TODO: split test apart to prepare for testing OCI/GCP
 //
 @Disabled
-public class TerraformTaskV2Test extends AbstractTerraformTest {
+class TerraformTaskV2Test extends AbstractTerraformTest {
     private ApiClient apiClient;
     private SecretService secretService;
     private final LockService lockService = mock(LockService.class);
@@ -96,7 +95,7 @@ public class TerraformTaskV2Test extends AbstractTerraformTest {
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         Map<String, Object> args = baseArguments(workDir, dstDir, Action.PLAN.name());
         args.put(TaskConstants.VARS_FILES, varFiles());
         args.put(TaskConstants.EXTRA_VARS_KEY, extraVars());


### PR DESCRIPTION
okhttp is only used in the (disabled) unit tests. This replaces the download manager backed with the native `HttpClient`.