### PR TITLE
git: add gson to pom for egit support

### DIFF
--- a/tasks/git/pom.xml
+++ b/tasks/git/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <jgit.version>6.5.0.202303070854-r</jgit.version>
+        <egit.github.version>6.1.0.202203080745-r</egit.github.version>
     </properties>
 
     <dependencies>
@@ -75,7 +76,15 @@
         <dependency>
             <groupId>org.eclipse.mylyn.github</groupId>
             <artifactId>org.eclipse.egit.github.core</artifactId>
-            <version>6.1.0.202203080745-r</version>
+            <version>${egit.github.version}</version>
+        </dependency>
+        <!-- For some reason this isn't included in org.eclipse.egit.github.core's
+             transitive dependencies.
+              https://github.com/eclipse-egit/egit-github/blob/v6.1.0.202203080745-r/org.eclipse.egit.github.core/README.md#core-orgeclipseegitgithubcore -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.7</version>
         </dependency>
 
         <dependency>

--- a/tasks/git/src/test/java/com/walmartlabs/concord/plugins/git/GitHubCommonTest.java
+++ b/tasks/git/src/test/java/com/walmartlabs/concord/plugins/git/GitHubCommonTest.java
@@ -1,0 +1,37 @@
+package com.walmartlabs.concord.plugins.git;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2024 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.eclipse.egit.github.core.client.GitHubClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class GitHubCommonTest {
+
+    @Test
+    void testCreateClient() {
+        GitHubClient client = GitHubClient.createClient("https://mock.github.local");
+
+        assertNotNull(client);
+    }
+
+}


### PR DESCRIPTION
Gson _should_ be a transitive dependency of `org.eclipse.egit.github.core`. I don't know why that's not true in practice. Since concord-client2 doesn't include gson anymore, this task now need to have it explicitly defined.