### PR TITLE
project: use concord maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             <plugins>
                 <plugin>
                     <groupId>dev.ybrig.concord</groupId>
-                    <artifactId>concord-maven-plugin-ng</artifactId>
+                    <artifactId>concord-maven-plugin</artifactId>
                     <version>0.0.29</version>
                     <configuration>
                         <concordVersion>${concord.version}</concordVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                 <plugin>
                     <groupId>dev.ybrig.concord</groupId>
                     <artifactId>concord-maven-plugin</artifactId>
-                    <version>0.0.29</version>
+                    <version>0.0.30</version>
                     <configuration>
                         <concordVersion>${concord.version}</concordVersion>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,22 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>dev.ybrig.concord</groupId>
+                    <artifactId>concord-maven-plugin-ng</artifactId>
+                    <version>0.0.29</version>
+                    <configuration>
+                        <concordVersion>${concord.version}</concordVersion>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>sisu-index</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.0.0-M6</version>
@@ -111,19 +127,6 @@
                         <localCheckout>true</localCheckout>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.eclipse.sisu</groupId>
-                    <artifactId>sisu-maven-plugin</artifactId>
-                    <version>0.3.5</version>
-                    <executions>
-                        <execution>
-                            <id>index</id>
-                            <goals>
-                                <goal>main-index</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/runtime/opentelemetry/pom.xml
+++ b/runtime/opentelemetry/pom.xml
@@ -157,7 +157,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/runtime/opentelemetry/pom.xml
+++ b/runtime/opentelemetry/pom.xml
@@ -156,8 +156,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/argocd/pom.xml
+++ b/tasks/argocd/pom.xml
@@ -178,8 +178,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.openapitools</groupId>

--- a/tasks/argocd/pom.xml
+++ b/tasks/argocd/pom.xml
@@ -179,7 +179,7 @@
             </plugin>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.openapitools</groupId>

--- a/tasks/aws/pom.xml
+++ b/tasks/aws/pom.xml
@@ -94,8 +94,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/aws/pom.xml
+++ b/tasks/aws/pom.xml
@@ -95,7 +95,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/confluence/pom.xml
+++ b/tasks/confluence/pom.xml
@@ -58,7 +58,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/confluence/pom.xml
+++ b/tasks/confluence/pom.xml
@@ -57,8 +57,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/git/pom.xml
+++ b/tasks/git/pom.xml
@@ -117,8 +117,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/git/pom.xml
+++ b/tasks/git/pom.xml
@@ -118,7 +118,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/gremlin/pom.xml
+++ b/tasks/gremlin/pom.xml
@@ -25,7 +25,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/gremlin/pom.xml
+++ b/tasks/gremlin/pom.xml
@@ -24,8 +24,8 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/jenkins/pom.xml
+++ b/tasks/jenkins/pom.xml
@@ -85,7 +85,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/jenkins/pom.xml
+++ b/tasks/jenkins/pom.xml
@@ -84,8 +84,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/jira/pom.xml
+++ b/tasks/jira/pom.xml
@@ -104,8 +104,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/jira/pom.xml
+++ b/tasks/jira/pom.xml
@@ -105,7 +105,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/jsonpath/pom.xml
+++ b/tasks/jsonpath/pom.xml
@@ -64,7 +64,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/jsonpath/pom.xml
+++ b/tasks/jsonpath/pom.xml
@@ -63,8 +63,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/ldap/pom.xml
+++ b/tasks/ldap/pom.xml
@@ -44,7 +44,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/ldap/pom.xml
+++ b/tasks/ldap/pom.xml
@@ -43,8 +43,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/msteams/pom.xml
+++ b/tasks/msteams/pom.xml
@@ -84,7 +84,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/msteams/pom.xml
+++ b/tasks/msteams/pom.xml
@@ -83,8 +83,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/packer/pom.xml
+++ b/tasks/packer/pom.xml
@@ -94,7 +94,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/packer/pom.xml
+++ b/tasks/packer/pom.xml
@@ -93,8 +93,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/s3/pom.xml
+++ b/tasks/s3/pom.xml
@@ -107,7 +107,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/s3/pom.xml
+++ b/tasks/s3/pom.xml
@@ -106,8 +106,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/terraform/pom.xml
+++ b/tasks/terraform/pom.xml
@@ -140,8 +140,8 @@
 
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/terraform/pom.xml
+++ b/tasks/terraform/pom.xml
@@ -141,7 +141,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tasks/xml/pom.xml
+++ b/tasks/xml/pom.xml
@@ -44,8 +44,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/xml/pom.xml
+++ b/tasks/xml/pom.xml
@@ -45,7 +45,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/zoom/pom.xml
+++ b/tasks/zoom/pom.xml
@@ -62,7 +62,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.ybrig.concord</groupId>
-                <artifactId>concord-maven-plugin-ng</artifactId>
+                <artifactId>concord-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/tasks/zoom/pom.xml
+++ b/tasks/zoom/pom.xml
@@ -61,8 +61,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
+                <groupId>dev.ybrig.concord</groupId>
+                <artifactId>concord-maven-plugin-ng</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
concord-maven-plugin: https://github.com/concord-workflow/concord-maven-plugin
A simple plugin that checks runtime and plugin dependency versions, ensuring runtime dependencies are marked as provided in the plugin. Currently, it doesn’t handle transitive dependencies


all tasks updated except `akeyless`:
```
[INFO] --- concord:0.0.29:verify (default) @ akeyless-task ---
[INFO] Resolving runtime-v2 dependencies for version '2.19.0'
[WARNING] The dependency 'com.fasterxml.jackson.core:jackson-core:2.13.3 (compile)' has an invalid version.
Expected version: '2.17.0'. Please update your POM.

[WARNING] The dependency 'com.fasterxml.jackson.core:jackson-annotations:2.13.3 (compile)' has an invalid version.
Expected version: '2.17.0'. Please update your POM.

[WARNING] The dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.3 (compile)' has an invalid version.
Expected version: '2.17.0'. Please update your POM.

[WARNING] The dependency 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3 (compile)' has an invalid version.
Expected version: '2.17.0'. Please update your POM.

[WARNING] Some dependencies of Concord Plugins are expected to be declared with a 'provided' scope.
Please check your POM file and ensure the following dependencies are correctly set with '<scope>provided</scope>':

 * com.fasterxml.jackson.core:jackson-core:2.13.3 (compile)
 * com.fasterxml.jackson.core:jackson-annotations:2.13.3 (compile)
 * com.fasterxml.jackson.core:jackson-databind:2.13.3 (compile)
 * com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3 (compile)
```