### PR TITLE
github: return `fake` PR ID in dry-run-mode for craeatePr action

### DIFF
--- a/tasks/git/src/main/java/com/walmartlabs/concord/plugins/git/GitHubTask.java
+++ b/tasks/git/src/main/java/com/walmartlabs/concord/plugins/git/GitHubTask.java
@@ -226,7 +226,7 @@ public class GitHubTask {
 
             if (dryRunMode) {
                 log.info("Dry-run mode enabled: Skipping PR creation");
-                return Map.of();
+                return Map.of("prId", 0); // let's return some `fake` ID
             }
 
             PullRequest result = prService.createPullRequest(repo, pr);


### PR DESCRIPTION
as a result, it will be possible to run in dry-run mode without making any changes:
```
...
- task: github
   in:
     action: createPr
   out: createResponse

- task: github
   in:
      action: closePr/mergePr/whatever  
      prId: "${createResponse.prId}"
...
```