### PR TITLE
argocd: use native http client

### DIFF
--- a/tasks/argocd/README.md
+++ b/tasks/argocd/README.md
@@ -1,0 +1,87 @@
+# `argocd` plugin for Concord
+
+
+## Integration Tests
+
+Integration tests run against a local ArgoCD instance. Run the [`install_argo.sh`](./local_argo/install_argo.sh)
+script to set up an instance including
+
+- Local K3s cluster in Docker
+- Basic ArgoCD installation
+- LDAP Dex connector
+- Git repository server
+- Default Repository in ArgoCD, with SSH keypair auth
+
+### Prerequisites
+
+- `git`
+- `docker` or `rancher`
+- `kubectl` (optionally `k9s`)
+- `ansible` with [`kubernetes` module](https://pypi.org/project/kubernetes/)
+    and [`kubernetes.core` collection](https://galaxy.ansible.com/ui/repo/published/kubernetes/core/)
+
+### Things To Know
+
+#### Ingress Hostname
+
+The trickiest part is getting a hostname to work both within docker (e.g. ITs executing
+through Concord testcontainers) and outside (e.g. direct JUnit ITs). The default
+setup uses `host.docker.internal`. That solves the internal problem. However, this
+requires some manual intervention on the host machine to resolve the hostname. This
+should be as simple as adding an `/etc/hosts` entry.
+
+```
+# ...leave existing entries
+
+# this is needed for the integration tests to work
+127.0.0.1 host.docker.internal
+```
+
+Alternatively, use a hostname or IP address which is accessible on your
+network (e.g. your workstation's IP address).
+
+#### Generated Files
+
+Some required values and files must be generated at install-time, and it's just
+cleaner to keep "secrets" (event for testing) out of the repository. All of these
+generated files are saved to the
+[`local_argo/playbook/roles/argocd/files`](./local_argo/playbook/roles/argocd/files)
+directory.
+
+- `argo_install_manifest.yml` - ArgoCD k8ts install manifest
+- `k3s_server_ca.crt` - kubernetes CA certificate
+- `k3s_token.txt` - init token for k3s
+- `kubeconfig.yaml` - kubeconfig for the k3s cluster
+- `ldap_cfg.txt` - admin password and user ldap info
+- `test_key` and `test_key.pub` - ssh keypair for git repo access
+- `test_input.properties` - consolidated info for integration test input
+
+### Install ArgoCD in K3s
+
+Use [install_argo.sh](./local_argo/install_argo.sh) to start a `k3s` instance with
+ArgoCD in the `argocd` namespace. This will also generate a `kubeconfig.yaml` which
+can be used to interact with the cluster (e.g. with `kubectl` or `k9s`) for debugging.
+
+```
+$ cd local_argo
+$ ./install_argo.sh --ingress-host <your-hostname-or-ip>
+```
+
+Optionally, skip downloading argocd manifest on first rut. Note: download will be
+skipped if the destination file already exists.
+
+```
+$ ./install_argo.sh --skip-manifest-download
+```
+
+### Run Integration Tests
+
+```
+# run mvn from project root
+$ mvn clean install --pl tasks/argocd
+$ mvn verify --pl tasks/argocd -DskipArgoITs=false
+...
+[INFO] Results:
+[INFO]
+[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
+```

--- a/tasks/argocd/local_argo/.gitignore
+++ b/tasks/argocd/local_argo/.gitignore
@@ -1,0 +1,2 @@
+playbook/roles/argocd/files/generated
+*venv

--- a/tasks/argocd/local_argo/docker-compose.yml
+++ b/tasks/argocd/local_argo/docker-compose.yml
@@ -1,0 +1,65 @@
+# to run define K3S_TOKEN, K3S_VERSION is optional, eg:
+#   K3S_TOKEN=${RANDOM}${RANDOM}${RANDOM} docker-compose up
+
+services:
+
+  server:
+    image: "rancher/k3s:${K3S_VERSION:-latest}"
+    command: server
+    tmpfs:
+      - /run
+      - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    restart: always
+    environment:
+      - K3S_TOKEN=${K3S_TOKEN:?err}
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    volumes:
+      - k3s-server:/var/lib/rancher/k3s
+      # This is just so that we get the kubeconfig file out
+      - ./playbook/roles/argocd/files/generated:/output
+    ports:
+      - 6443:6443  # Kubernetes API Server
+      - 80:80      # Ingress controller port 80
+      - 443:443    # Ingress controller port 443
+      - 8080:8080  # port forward TODO be smarter (set up ingress to argo through ^^443^^)
+    networks:
+      - argo-net
+
+  agent:
+    image: "rancher/k3s:${K3S_VERSION:-latest}"
+    tmpfs:
+      - /run
+      - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    restart: always
+    environment:
+      - K3S_URL=https://server:6443
+      - K3S_TOKEN=${K3S_TOKEN:?err}
+    volumes:
+      - k3s-agent:/var/lib/rancher/k3s
+    networks:
+      - argo-net
+
+volumes:
+  k3s-server: {}
+  k3s-agent: {}
+
+networks:
+  argo-net:
+    ipam:
+      config:
+        - ip_range: "192.168.90.0/24"
+          subnet: "192.168.90.0/24"
+          gateway: "192.168.90.1"

--- a/tasks/argocd/local_argo/install_argo.sh
+++ b/tasks/argocd/local_argo/install_argo.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -o pipefail
+set -o errexit
+
+printHelp() {
+    echo "usage: $0 [-h] [---skip-manifest-download]"
+}
+
+function join_by {
+    local IFS="$1";
+    shift;
+    echo "$*";
+}
+
+ingressHostname="host.docker.internal"
+generatedFilesDir="playbook/roles/argocd/files/generated"
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -h | --help )             printHelp
+                                  exit
+                                  ;;
+        -i | --ingress-hostname ) shift
+                                  ingressHostname="${1}"
+                                  ;;
+        -s | --skip-manifest-download )
+                                  skipManifestDownload="true"
+                                  ;;
+        * )
+            echo "Invalid parameter '$1'"
+            printHelp
+            exit 1
+    esac
+    # Shift all the parameters down by one
+    shift
+done
+
+# install argocd
+
+mkdir -p "${generatedFilesDir}"
+
+if [ -f "${generatedFilesDir}/k3s_token.txt" ]; then
+  K3S_TOKEN=$(cat "${generatedFilesDir}/k3s_token.txt")
+else
+  K3S_TOKEN=$(head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 32 | tee "${generatedFilesDir}/k3s_token.txt")
+fi
+
+export K3S_TOKEN
+docker compose up -d
+
+sleep 5
+
+mkdir -p "${generatedFilesDir}"
+
+# export server ca so ansible is less cranky
+docker cp local_argo-server-1:/var/lib/rancher/k3s/server/tls/server-ca.crt "${generatedFilesDir}/k3s_server_ca.crt"
+
+if [ -f "${generatedFilesDir}/ldap_cfg.txt" ]; then
+  ldapAdminPassword=$(grep 'adminPassword:' "${generatedFilesDir}/ldap_cfg.txt" | sed 's/adminPassword://')
+  ldapUsername=$(grep 'username:' "${generatedFilesDir}/ldap_cfg.txt" | sed 's/username://')
+  ldapPassword=$(grep 'password:' "${generatedFilesDir}/ldap_cfg.txt" | sed 's/password://')
+else
+  ldapAdminPassword=$(head /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9' | head -c 32)
+  read -r -p    "Enter LDAP username: " ldapUsername
+  read -r -s -p "Enter LDAP password: " ldapPassword
+
+  echo "adminPassword:${ldapAdminPassword}" >  "${generatedFilesDir}/ldap_cfg.txt"
+  echo "username:${ldapUsername}"           >> "${generatedFilesDir}/ldap_cfg.txt"
+  echo "password:${ldapPassword}"           >> "${generatedFilesDir}/ldap_cfg.txt"
+fi
+
+# argocd kubernetes manifest
+if [[ -f "${generatedFilesDir}/argo_install_manifest.yml" || "${skipManifestDownload}" == *"true"* ]]; then
+    echo "Skipping manifest download"
+else
+    echo "Downloading latest ArgoCD manifest"
+    curl -o "${generatedFilesDir}/argo_install_manifest.yml" https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+fi
+
+# keypair for git in-cluster git operations
+if [[ ! -f "${generatedFilesDir}/test_key" ]]
+then
+   ssh-keygen -t rsa -b 4096 -C "test@example.com" -m pem -N '' -f "${generatedFilesDir}/test_key"
+fi
+
+# python3 -m venv localvenv
+# source localvenv/bin/activate
+# pip install kubernetes
+# ansible-galaxy collection install kubernetes.core
+ansible-playbook -i ./playbook/inventory.yml \
+  -e ingress_hostname="${ingressHostname}" \
+  -e ldap_admin_password="${ldapAdminPassword}" \
+  -e ldap_username="${ldapUsername}" \
+  -e ldap_password="${ldapPassword}" \
+  ./playbook/main.yml
+
+cat > "${generatedFilesDir}/test_input.properties" << EOF
+ARGO_IT_APP_NAMESPACE=test-namespace
+ARGO_IT_BASE_API=https://${ingressHostname}
+ARGO_IT_BASIC_ADMIN_PASSWORD=$(< "${generatedFilesDir}/argocd_admin_password.txt")
+ARGO_IT_KUBECONFIG_PATH=local_argo/${generatedFilesDir}/kubeconfig.yaml
+ARGO_IT_LDAP_USERNAME=${ldapUsername}
+ARGO_IT_LDAP_PASSWORD=${ldapPassword}
+EOF

--- a/tasks/argocd/local_argo/playbook/inventory.yml
+++ b/tasks/argocd/local_argo/playbook/inventory.yml
@@ -1,0 +1,9 @@
+---
+local:
+  hosts:
+    k3s:
+      ansible_host: localhost
+      kubconfig_path: roles/argocd/files/generated/kubeconfig.yaml
+      k8s_ca_cert: roles/argocd/files/generated/k3s_server_ca.crt
+      ansible_connection: local
+      k8s_ns: argocd

--- a/tasks/argocd/local_argo/playbook/main.yml
+++ b/tasks/argocd/local_argo/playbook/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Main playbook
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: argocd

--- a/tasks/argocd/local_argo/playbook/roles/argocd/files/test_deployment.yaml
+++ b/tasks/argocd/local_argo/playbook/roles/argocd/files/test_deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: nginx-cm
+  name: nginx-cm
+data:
+  index.html: "hello world"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      volumes:
+        - name: nginx-static-volume
+          configMap:
+            name: nginx-cm
+            items:
+              - key: "index.html"
+                path: "index.html"
+      containers:
+        - name: nginx
+          image: library/nginx:latest
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 15 # force a slow-ish startup, useful for testing timeouts
+            periodSeconds: 5
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: nginx-static-volume
+              mountPath: "/usr/share/nginx/html"
+              readOnly: true

--- a/tasks/argocd/local_argo/playbook/roles/argocd/tasks/main.yml
+++ b/tasks/argocd/local_argo/playbook/roles/argocd/tasks/main.yml
@@ -1,0 +1,243 @@
+---
+- name: Execute with k8s defaults
+  module_defaults:
+    kubernetes.core.k8s:
+      kubeconfig: "{{ kubconfig_path }}"
+      ca_cert: "{{ k8s_ca_cert }}"
+      namespace: "{{ k8s_ns }}"
+    kubernetes.core.k8s_info:
+      kubeconfig: "{{ kubconfig_path }}"
+      ca_cert: "{{ k8s_ca_cert }}"
+      namespace: "{{ k8s_ns }}"
+  vars:
+    # for query lookup
+    kubeconfig: "{{playbook_dir }}/{{ kubconfig_path }}"
+    ca_cert: "{{playbook_dir }}/{{ k8s_ca_cert }}"
+  block:
+    - name: "Create namespaces"
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ item }}"
+      loop: [ 'argocd', 'test-namespace']
+
+    - name: Apply argocd manifest to the cluster.
+      kubernetes.core.k8s:
+        state: present
+        src: files/generated/argo_install_manifest.yml
+
+    - name: "Update ArgoCD configmap"
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition: |
+          metadata:
+            name: argocd-cm
+          kind: ConfigMap
+          data:
+            url: "https://{{ ingress_hostname }}"
+            dex.config: |
+              connectors:
+              - type: ldap
+                id: ldap
+                name: LocalLLDAP
+                config:
+                  host: "oldap-svc:1389"
+                  insecureNoSSL: true
+                  insecureSkipVerify: true
+                  bindDN: "cn=admin,dc=example,dc=org"
+                  bindPW: "{{ ldap_admin_password }}"
+                  usernamePrompt: SSO Username
+                  userSearch:
+                    baseDN: "dc=example,dc=org"
+                    filter: ""
+                    username: uid
+                    idAttr: uid
+                    emailAttr: mail
+                    nameAttr: givenName
+                    preferredUsernameAttr: uid
+                  groupSearch:
+                    baseDN: "dc=example,dc=org"
+                    # Optional filter to apply when searching the directory.
+                    filter: "(objectClass=posixGroup)"
+                    # Following list contains field pairs that are used to match a user to a group. It adds an additional
+                    # requirement to the filter that an attribute in the group must match the user's
+                    # attribute value.
+                    userMatchers:
+                    - userAttr: uid
+                      groupAttr: memberUid
+                    nameAttr: cn
+
+    - name: "Update ArgoCD rbac configmap"
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition: |
+          metadata:
+            name: argocd-rbac-cm
+          kind: ConfigMap
+          data:
+            scopes: '[groups, email]'
+            policy.default: 'role:readonly'
+            policy.csv: |
+              g, {{ ldap_username }}@mail.local, role:admin
+
+    - name: "Update ArgoCD params configmap"
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition: |
+          metadata:
+            name: argocd-cmd-params-cm
+          kind: ConfigMap
+          data:
+            server.insecure: "true"
+      register: params_map
+
+    - name: "Delete/restart argo-server"
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/name = argocd-server
+      when: params_map.changed
+
+    - name: Wait for traefik ingressroute CRD to exist
+      kubernetes.core.k8s_info:
+        kind: "CustomResourceDefinition"
+        name: "ingressroutes.traefik.containo.us"
+      register: result
+      until: result.resources | length > 0
+      retries: 36
+      delay: 5
+
+    # current argo docs are for traefik v3, but k3s at the time of working on this is
+    # shipping with v2. Check older docs for that example
+    # https://github.com/argoproj/argo-cd/blob/82db16664e0f3574c8bc6f52ede7dbc9af99eb6a/docs/operator-manual/ingress.md?plain=1
+    - name: "Create argo ingress"
+      kubernetes.core.k8s:
+        state: present
+        apply: true # overwrite existing
+        definition: |
+          apiVersion: traefik.containo.us/v1alpha1
+          kind: IngressRoute
+          metadata:
+            name: argocd-server
+          spec:
+            entryPoints:
+              - websecure
+            routes:
+              - kind: Rule
+                match: Host(`{{ ingress_hostname }}`)
+                priority: 10
+                services:
+                  - name: argocd-server
+                    port: 80
+              - kind: Rule
+                match: Host(`{{ ingress_hostname }}`) && Headers(`Content-Type`, `application/grpc`)
+                priority: 11
+                services:
+                  - name: argocd-server
+                    port: 80
+                    scheme: h2c
+          tls:
+            certResolver: default
+
+    - name: Verify the ArgoCD server is up and running
+      uri:
+        url: "https://{{ ingress_hostname }}"
+        status_code: 200
+        return_content: true
+        validate_certs: false
+      register: result
+      until: result.status == 200
+      retries: 36
+      delay: 5
+
+    - name: "Deploy OLDAP server manifest"
+      kubernetes.core.k8s:
+        state: present
+        apply: true
+        definition: "{{ lookup('template', 'oldap_manifest.yaml') }}"
+
+    - name: "Deploy git server manifest"
+      kubernetes.core.k8s:
+        state: present
+        apply: true
+        definition: "{{ lookup('template', 'git_manifest.yaml') }}"
+      register: git_deploy
+
+    - name: "Delete/restart git"
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        label_selectors:
+          - app = git
+      when: git_deploy.changed
+
+    - name: Fetch ArgoCD admin password
+      set_fact:
+        argoAdminPassword: |-
+          {{ query('kubernetes.core.k8s',
+              kind='Secret',
+              namespace='argocd',
+              resource_name='argocd-initial-admin-secret',
+              ca_cert=ca_cert,
+              kubeconfig=kubeconfig)[0].data.password | ansible.builtin.b64decode }}
+
+    - name: "Write admin password to generate files"
+      ansible.builtin.copy:
+        content: "{{ argoAdminPassword }}"
+        dest: "{{ role_path }}/files/generated/argocd_admin_password.txt"
+        mode: "0600"
+
+    - name: Get ArgoCD API token
+      ansible.builtin.uri:
+        url: https://{{ ingress_hostname }}/api/v1/session
+        method: POST
+        body: "{\"username\":\"admin\",\"password\":\"{{ argoAdminPassword }}\"}"
+        status_code: 200
+        body_format: json
+        validate_certs: false
+      register: session_token_resp
+
+    - set_fact:
+        api_jwt: "{{ session_token_resp.json.token }}"
+
+    - name: List repositories
+      ansible.builtin.uri:
+        url: https://{{ ingress_hostname }}/api/v1/repositories
+        method: GET
+        status_code: 200
+        validate_certs: false
+        headers:
+          Authorization: "Bearer {{ api_jwt }}"
+      register: repositories_resp
+
+    - name: "Create default repository"
+      when: (repositories_resp['json']['items'] == None) or (repositories_resp['json']['items'] | length == 0)
+      block:
+        - name: Create default repository
+          ansible.builtin.uri:
+            url: https://{{ ingress_hostname }}/api/v1/repositories
+            method: POST
+            body: |
+              {
+                "repo": "ssh://git@git-svc:22/git-server/repos/myrepo.git",
+                "insecure": true,
+                "type": "git",
+                "name": "myrepo",
+                "project": "default",
+                "sshPrivateKey": {{ lookup('file', 'generated/test_key') | to_json }}
+              }
+            status_code: 200
+            body_format: json
+            validate_certs: false
+            headers:
+              Authorization: "Bearer {{ api_jwt }}"

--- a/tasks/argocd/local_argo/playbook/roles/argocd/templates/git_manifest.yaml
+++ b/tasks/argocd/local_argo/playbook/roles/argocd/templates/git_manifest.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: git
+  name: git
+data:
+  git.key01.pub: |
+    {{ lookup('file', 'generated/test_key.pub') | indent( width=4 ) }}
+  git.repo01.file: |
+    {{ lookup('file', 'test_deployment.yaml') | indent( width=4 ) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: git
+  labels:
+    app: git
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: git
+  template:
+    metadata:
+      labels:
+        app: git
+    spec:
+      volumes:
+        - name: git-public-key-volume
+          configMap:
+            name: git
+            items:
+              - key: "git.key01.pub"
+                path: "git.key01.pub"
+        - name: git-repos-volume
+          configMap:
+            name: git
+            items:
+              - key: "git.repo01.file"
+                path: "manifest.yaml"
+      containers:
+        - name: git
+          image: jkarlos/git-server-docker:latest
+          ports:
+            - containerPort: 22
+          volumeMounts:
+            - name: git-public-key-volume
+              mountPath: "/git-server/keys"
+              readOnly: true
+            - name: git-repos-volume
+              mountPath: "/repo_src"
+              readOnly: false
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "mkdir -p /git-server/repos/myrepo.git/app; cp /repo_src/..data/manifest.yaml /git-server/repos/myrepo.git/app/manifest.yaml; cd /git-server/repos/myrepo.git; git init; git add app; git config --global user.email me@mail.local; git config --global user.name me; git commit -m init;"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: git-svc
+spec:
+  clusterIP: None # headless service
+  ports:
+    - name: http
+      port: 10022
+      protocol: TCP
+      targetPort: 22
+  selector:
+    app: git

--- a/tasks/argocd/local_argo/playbook/roles/argocd/templates/oldap_manifest.yaml
+++ b/tasks/argocd/local_argo/playbook/roles/argocd/templates/oldap_manifest.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: oldap-seed
+  name: oldap-seed
+data:
+  oldap.ldif: |
+    version: 1
+    
+    dn: cn={{ ldap_username }},dc=example,dc=org
+    cn: {{ ldap_username }}
+    displayName: Ldap User
+    mail: {{ ldap_username }}@mail.local
+    gidnumber: 10000
+    givenName: Ldap
+    homedirectory: /home/{{ ldap_username }}
+    loginshell: /bin/bash
+    objectclass: posixAccount
+    objectclass: inetOrgPerson
+    objectclass: organizationalPerson
+    objectclass: person
+    sn: User
+    uid: {{ ldap_username }}
+    uidnumber: 10000
+    userpassword: {{ ldap_password }}
+    
+    dn: cn=admin-group,dc=example,dc=org
+    objectClass: posixGroup
+    gidNumber: 10001
+    cn: admin-group
+    memberUid: {{ ldap_username }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oldap
+  labels:
+    app: oldap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oldap
+  template:
+    metadata:
+      labels:
+        app: oldap
+    spec:
+      volumes:
+        - name: oldap-seed-volume
+          configMap:
+            name: oldap-seed
+            items:
+              - key: "oldap.ldif"
+                path: "oldap.ldif"
+      containers:
+        - name: oldap
+          image: bitnami/openldap:latest
+          env:
+            - name: LDAP_ADMIN_USERNAME
+              value: "admin"
+            - name: LDAP_ADMIN_PASSWORD
+              value: "{{ ldap_admin_password }}"
+            - name: LDAP_ROOT
+              value: "dc=example,dc=org"
+            - name: LDAP_ADMIN_DN
+              value: "cn=admin,dc=example,dc=org"
+          ports:
+            - containerPort: 1389
+          volumeMounts:
+            - name: oldap-seed-volume
+              mountPath: "/import_data"
+              readOnly: true
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5; ldapmodify -a -x -D cn=admin,dc=example,dc=org -w '{{ ldap_admin_password }}'  -H ldap://localhost:1389 -f /import_data/oldap.ldif"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oldap-svc
+spec:
+  clusterIP: None # headless service
+  ports:
+    - name: http
+      port: 1389
+      protocol: TCP
+      targetPort: 1389
+  selector:
+    app: oldap

--- a/tasks/argocd/pom.xml
+++ b/tasks/argocd/pom.xml
@@ -12,14 +12,18 @@
     <packaging>takari-jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <skipArgoITs>true</skipArgoITs>
+
+        <testcontainers.concord.version>2.0.1</testcontainers.concord.version>
         <swagger-annotations-version>1.5.21</swagger-annotations-version>
         <httpclient-version>4.5.13</httpclient-version>
         <jackson-version>2.13.3</jackson-version>
-        <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
+        <jackson-threetenbp-version>2.18.2</jackson-threetenbp-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>
-        <threetenbp-version>1.4.0</threetenbp-version>
+        <threetenbp-version>1.7.1</threetenbp-version>
     </properties>
 
     <dependencies>
@@ -57,6 +61,7 @@
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -84,6 +89,30 @@
             <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-jetty12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ca.ibodrov.concord</groupId>
+            <artifactId>testcontainers-concord-core</artifactId>
+            <version>${testcontainers.concord.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ca.ibodrov.concord</groupId>
+            <artifactId>testcontainers-concord-junit5</artifactId>
+            <version>${testcontainers.concord.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+
         <!-- https://mvnrepository.com/artifact/com.microsoft.identity.client/msal -->
         <!-- https://mvnrepository.com/artifact/com.microsoft.azure/msal4j -->
         <dependency>
@@ -95,32 +124,13 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-
-        <!-- HTTP client: apache client -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpclient-version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
-            <version>${httpclient-version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -151,14 +161,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.joschi.jackson</groupId>
-            <artifactId>jackson-datatype-threetenbp</artifactId>
-            <version>${jackson-threetenbp-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.threeten</groupId>
-            <artifactId>threetenbp</artifactId>
-            <version>${threetenbp-version}</version>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.6</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
@@ -166,9 +171,37 @@
             <version>${jakarta-annotation-version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <filtering>false</filtering>
+                <directory>${project.basedir}/src/test/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </testResource>
+            <testResource>
+                <filtering>true</filtering>
+                <directory>${project.basedir}/src/test/filtered-resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </testResource>
+        </testResources>
+
         <plugins>
             <plugin>
                 <groupId>io.takari.maven.plugins</groupId>
@@ -195,7 +228,7 @@
                                 ${project.basedir}/argocd.yml
                             </inputSpec>
                             <generatorName>java</generatorName>
-                            <library>apache-httpclient</library>
+                            <library>native</library>
                             <packageName>com.walmartlabs.concord.plugins.argocd.openapi</packageName>
                             <apiPackage>com.walmartlabs.concord.plugins.argocd.openapi.api</apiPackage>
                             <modelPackage>com.walmartlabs.concord.plugins.argocd.openapi.model</modelPackage>
@@ -210,6 +243,25 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipITs>${skipArgoITs}</skipITs>
+                    <includes>
+                        <include>**/*IT</include>
+                    </includes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdConstants.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ArgoCdConstants.java
@@ -28,12 +28,10 @@ public class ArgoCdConstants {
 
     static final String CREATE_NAMESPACE_OPTION = "CreateNamespace=true";
 
-    static final Map<String, Object> SYNC_POLICY = Collections.unmodifiableMap(new HashMap<String, Object>() {{
-        put("automated", new HashMap<String, Object>() {{
-            put("prune", true);
-            put("selfHeal", true);
-        }});
-    }});
+    static final Map<String, Object> SYNC_POLICY = Map.of("automated", Map.of(
+            "prune", true,
+            "selfHeal", true
+    ));
 
     static final String ARGOCD_NAMESPACE = "argocd";
 

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/NoopTrustManager.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/NoopTrustManager.java
@@ -1,0 +1,76 @@
+package com.walmartlabs.concord.plugins.argocd;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.net.Socket;
+import java.security.cert.X509Certificate;
+
+/**
+ * Trust manager which trusts everything. Not recommended for production usage,
+ * but helpful with test environments.
+ */
+public class NoopTrustManager extends X509ExtendedTrustManager {
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        // no validation
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        // no validation
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {
+        // no validation
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {
+        // no validation
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
+        // no validation
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
+        // no validation
+    }
+
+    public static TrustManager[] getManagers() {
+        TrustManager[] managers = new TrustManager[1];
+
+        managers[0] = new NoopTrustManager();
+        return managers;
+    }
+}

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ObjectMapper.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/ObjectMapper.java
@@ -77,9 +77,12 @@ public class ObjectMapper {
     }
 
     public <T> T mapToModel(Map<String, Object> map, Class<T> model) throws IOException {
-        return (T) readValue(writeValueAsString(map), model);
+        return readValue(writeValueAsString(map), model);
     }
 
+    public com.fasterxml.jackson.databind.ObjectMapper getDelegate() {
+        return delegate;
+    }
 
     public V1alpha1Application buildApplicationObject(TaskParams.CreateUpdateParams in) throws IOException {
         Map<String, Object> metadata = new HashMap<>();

--- a/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/model/HttpExecutor.java
+++ b/tasks/argocd/src/main/java/com/walmartlabs/concord/plugins/argocd/model/HttpExecutor.java
@@ -1,0 +1,31 @@
+package com.walmartlabs.concord.plugins.argocd.model;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.plugins.argocd.openapi.ApiException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpRequest;
+
+public interface HttpExecutor {
+    InputStream execute(HttpRequest request) throws ApiException, IOException, InterruptedException;
+}

--- a/tasks/argocd/src/test/filtered-resources/version.properties
+++ b/tasks/argocd/src/test/filtered-resources/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoIT.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoIT.java
@@ -1,0 +1,163 @@
+package com.walmartlabs.concord.plugins.argocd.it;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import ca.ibodrov.concord.testcontainers.Concord;
+import ca.ibodrov.concord.testcontainers.ConcordProcess;
+import ca.ibodrov.concord.testcontainers.Payload;
+import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.walmartlabs.concord.client2.ProcessEntry;
+import com.walmartlabs.concord.client2.ProjectEntry;
+import com.walmartlabs.concord.client2.ProjectsApi;
+import com.walmartlabs.concord.common.IOUtils;
+import com.walmartlabs.concord.plugins.argocd.ObjectMapper;
+import com.walmartlabs.concord.plugins.argocd.openapi.model.V1ObjectMeta;
+import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1Application;
+import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1ApplicationSource;
+import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1ApplicationSpec;
+import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1ApplicationStatus;
+import com.walmartlabs.concord.plugins.argocd.openapi.model.V1alpha1HealthStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
+
+import static ca.ibodrov.concord.testcontainers.Utils.randomString;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
+@WireMockTest
+public class ArgoIT {
+
+    @RegisterExtension
+    public static final ConcordRule concord = new ConcordRule()
+            .mode(Concord.Mode.DOCKER)
+            .serverImage("walmartlabs/concord-server:2.14.2")
+            .agentImage("walmartlabs/concord-agent:2.14.2")
+            .streamServerLogs(false)
+            .streamAgentLogs(false)
+            .useLocalMavenRepository(true);
+
+    private static final String CURRENT_VERSION = getCurrentVersion();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        stubFor(get(urlEqualTo("/auth/login?connector_id=ldap"))
+                .willReturn(aResponse()
+                        .withBody("{}")
+                        .withStatus(200)));
+
+        stubFor(post(urlEqualTo("/auth/login?connector_id=ldap"))
+                .willReturn(aResponse()
+                        .withBody("{}")
+                        .withStatus(200)));
+
+        stubFor(get(urlEqualTo("/api/v1/applications/test?refresh=false"))
+                .willReturn(aResponse()
+                        .withBody(mockApplication())
+                        .withStatus(200)));
+    }
+
+    @Test
+    void testRuntimeV2(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String concordYmlSource = "runtimeV2/concord.yml";
+
+        String orgName = "org_" + randomString();
+        concord.organizations().create(orgName);
+
+        String projectName = "project_" + randomString();
+        concord.projects().create(orgName, projectName);
+
+        var projectsApi = new ProjectsApi(concord.apiClient());
+        var project = projectsApi.getProject(orgName, projectName);
+        project.setAcceptsRawPayload(true);
+        project.rawPayloadMode(ProjectEntry.RawPayloadModeEnum.EVERYONE);
+        projectsApi.createOrUpdateProject(orgName, project);
+
+        Payload payload = new Payload()
+                .org(orgName)
+                .project(projectName)
+                .arg("argoBaseUrl", "http://host.docker.internal:" + wmRuntimeInfo.getHttpPort())
+                .concordYml(new String(readToBytes(concordYmlSource))
+                        .replace("%%version%%", CURRENT_VERSION));
+
+        //  ---
+
+        ConcordProcess proc = concord.processes().start(payload);
+        proc.waitForStatus(ProcessEntry.StatusEnum.FINISHED);
+
+        //  ---
+
+        proc.assertLog(".*got app status: Healthy.*");
+    }
+
+    private static String getCurrentVersion() {
+        Properties props = new Properties();
+        try (InputStream in = ClassLoader.getSystemResourceAsStream("version.properties")) {
+            props.load(in);
+            return props.getProperty("version");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static byte[] readToBytes(String resource) {
+        try (InputStream in = ArgoIT.class.getResourceAsStream(resource)) {
+            if (Objects.isNull(in)) {
+                throw new IllegalStateException("Failed to load resource: " + resource);
+            }
+
+            return IOUtils.toByteArray(in);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String mockApplication() {
+
+        var app = new V1alpha1Application()
+                .metadata(new V1ObjectMeta()
+                        .name("test")
+                        .namespace("test-ns"))
+                .spec(new V1alpha1ApplicationSpec()
+                        .project("default")
+                        .source(new V1alpha1ApplicationSource()
+                                .repoURL("https://github.com/argoproj/argocd-example-apps.git")
+                                .targetRevision("HEAD")))
+                .operation(null)
+                .status(new V1alpha1ApplicationStatus()
+                        .health(new V1alpha1HealthStatus()
+                                .status("Healthy")));
+
+        try {
+            return MAPPER.writeValueAsString(app);
+        } catch (IOException e) {
+            throw new IllegalStateException("Error generating mock argo application: " + e.getMessage());
+        }
+    }
+}

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoK3sIT.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoK3sIT.java
@@ -1,0 +1,208 @@
+package com.walmartlabs.concord.plugins.argocd.it;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2025 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import ca.ibodrov.concord.testcontainers.Concord;
+import ca.ibodrov.concord.testcontainers.ConcordProcess;
+import ca.ibodrov.concord.testcontainers.Payload;
+import ca.ibodrov.concord.testcontainers.junit5.ConcordRule;
+import com.walmartlabs.concord.client2.ProcessEntry;
+import com.walmartlabs.concord.client2.ProjectEntry;
+import com.walmartlabs.concord.client2.ProjectsApi;
+import com.walmartlabs.concord.plugins.argocd.ArgoCdClient;
+import com.walmartlabs.concord.plugins.argocd.ImmutableTestBasicAuth;
+import com.walmartlabs.concord.plugins.argocd.ImmutableTestGetParams;
+import com.walmartlabs.concord.plugins.argocd.ImmutableTestLdapAuth;
+import com.walmartlabs.concord.plugins.argocd.TaskParams;
+import org.immutables.value.Value;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+
+import static ca.ibodrov.concord.testcontainers.Utils.randomString;
+import static com.github.tomakehurst.wiremock.core.Version.getCurrentVersion;
+import static com.walmartlabs.concord.plugins.argocd.it.ArgoIT.readToBytes;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ArgoK3sIT {
+
+    @RegisterExtension
+    public static final ConcordRule concord = new ConcordRule()
+            .mode(Concord.Mode.DOCKER)
+            .serverImage("walmartlabs/concord-server:2.14.2")
+            .agentImage("walmartlabs/concord-agent:2.14.2")
+            .streamServerLogs(false)
+            .streamAgentLogs(false)
+            .useLocalMavenRepository(true);
+
+    private static final Logger log = LoggerFactory.getLogger(ArgoK3sIT.class);
+    private static final String CURRENT_VERSION = getCurrentVersion();
+    private static final ItArgs IT_ARGS = ItArgs.create();
+
+    @BeforeAll
+    static void setUp() {
+        log.info("Concord IT server: {}", concord.apiBaseUrl());
+        log.info("Concord IT admin token: {}", concord.environment().apiToken());
+    }
+
+    @Test
+    void testBasicAuth() throws Exception {
+        var in = ImmutableTestGetParams.builder()
+                .app("test-app")
+                .baseUrl(IT_ARGS.baseUrl())
+                .action(TaskParams.Action.GETPROJECT)
+                .validateCerts(false)
+                .auth(ImmutableTestBasicAuth.builder()
+                        .username("admin")
+                        .password(IT_ARGS.basicAdminPassword())
+                        .build())
+                .build();
+
+        var out = new ArgoCdClient(in).listApplicationSets(List.of(), null);
+
+        assertNotNull(out);
+    }
+
+    @Test
+    void testLdapAuth() throws Exception {
+        var in = ImmutableTestGetParams.builder()
+                .app("test-app")
+                .baseUrl(IT_ARGS.baseUrl())
+                .action(TaskParams.Action.GETPROJECT)
+                .validateCerts(false)
+                .auth(ImmutableTestLdapAuth.builder()
+                        .username(IT_ARGS.ldapUsername())
+                        .password(IT_ARGS.ldapPassword())
+                        .build())
+                .build();
+
+        var out = new ArgoCdClient(in).listApplicationSets(List.of(), null);
+
+        assertNotNull(out);
+    }
+
+    @Test
+    void testFlow() throws Exception {
+        String concordYmlSource = "full/concord.yml";
+
+        String orgName = "org_" + randomString();
+        concord.organizations().create(orgName);
+
+        String projectName = "project_" + randomString();
+        concord.projects().create(orgName, projectName);
+
+        var projectsApi = new ProjectsApi(concord.apiClient());
+        var project = projectsApi.getProject(orgName, projectName);
+        project.setAcceptsRawPayload(true);
+        project.rawPayloadMode(ProjectEntry.RawPayloadModeEnum.EVERYONE);
+        projectsApi.createOrUpdateProject(orgName, project);
+
+        var payload = new Payload()
+                .org(orgName)
+                .project(projectName)
+                .arg("argoBaseUrl", IT_ARGS.baseUrl())
+                .arg("argoUsername", IT_ARGS.ldapUsername())
+                .arg("argoPassword", IT_ARGS.ldapPassword())
+                .arg("appNamespace", IT_ARGS.appNamespace())
+                .concordYml(new String(readToBytes(concordYmlSource))
+                        .replace("%%version%%", CURRENT_VERSION));
+
+        //  ---
+
+        ConcordProcess proc = concord.processes().start(payload);
+        proc.waitForStatus(ProcessEntry.StatusEnum.FINISHED);
+
+        //  ---
+
+        // should have forces a timeout with short setting, then success on second longer-timeout attempt
+        proc.assertLogAtLeast(".*Call attempt timed out after 5000ms.*", 1);
+        proc.assertLog(".*got app status: Healthy.*");
+        proc.assertLog(".*Deleted app: true.*");
+    }
+
+    protected static String getEnv(String name, String defValue) {
+        String envValue = System.getenv(name);
+
+        if (envValue == null) {
+            return defValue;
+        } else {
+            return envValue;
+        }
+    }
+
+    @Value.Immutable
+    @Value.Style(jdkOnly = true)
+    public interface ItArgs {
+        Path kubeconfigPath();
+
+        String baseUrl();
+
+        String basicAdminPassword();
+
+        String ldapUsername();
+
+        String ldapPassword();
+
+        String appNamespace();
+
+        static ItArgs create() {
+            var propsLocation = getEnv("ARGO_IT_TEST_INPUT", "local_argo/playbook/roles/argocd/files/generated/test_input.properties");
+            var testInput = Paths.get(propsLocation);
+
+            if (propsLocation.isBlank()) {
+                throw new IllegalArgumentException("ARGO_IT_TEST_INPUT is blank");
+            }
+
+            if (!Files.exists(testInput)) {
+                log.info("Test input file does not exist");
+                log.info("HINT: Run ./installArgo.sh to generate file, or set " +
+                        "ARGO_IT_TEST_INPUT to the path of the test input file");
+                throw new IllegalArgumentException("Test input file does not exist: " + testInput);
+            }
+
+            Properties props = new Properties();
+            try (var in = Files.newInputStream(testInput)) {
+                props.load(in);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            return ImmutableItArgs.builder()
+                    .kubeconfigPath(Paths.get(props.getProperty("ARGO_IT_KUBECONFIG_PATH")))
+                    .baseUrl(props.getProperty("ARGO_IT_BASE_API"))
+                    .basicAdminPassword(props.getProperty("ARGO_IT_BASIC_ADMIN_PASSWORD"))
+                    .ldapUsername(props.getProperty("ARGO_IT_LDAP_USERNAME"))
+                    .ldapPassword(props.getProperty("ARGO_IT_LDAP_PASSWORD"))
+                    .appNamespace(props.getProperty("ARGO_IT_APP_NAMESPACE"))
+                    .build();
+        }
+    }
+
+}

--- a/tasks/argocd/src/test/resources/com/walmartlabs/concord/plugins/argocd/it/full/concord.yml
+++ b/tasks/argocd/src/test/resources/com/walmartlabs/concord/plugins/argocd/it/full/concord.yml
@@ -1,0 +1,95 @@
+configuration:
+  runtime: "concord-v2"
+  dependencies:
+    - "mvn://com.walmartlabs.concord.plugins:argocd-task:%%version%%"
+#    - "mvn://com.walmartlabs.concord.plugins:argocd-task:2.7.0"
+
+flows:
+  default:
+    - name: "Get a project at ${argoBaseUrl}"
+      task: argocd
+      in:
+        action: getProject
+        baseUrl: "${argoBaseUrl}"
+        project: default
+        validateCerts: false
+        auth:
+          ldap:
+            username: "${argoUsername}"
+            password: "${argoPassword}"
+      out: result
+
+    - name: "Create an application"
+      task: argocd
+      in:
+        validateCerts: false
+        action: create
+        baseUrl: "${argoBaseUrl}"
+        auth:
+          ldap:
+            username: "${argoUsername}"
+            password: "${argoPassword}"
+        app: test-app
+        namespace: "${appNamespace}"
+        cluster: in-cluster
+        project: default
+        gitRepo:
+          repoUrl: ssh://git@git-svc:22/git-server/repos/myrepo.git
+          path: app
+          targetRevision: HEAD
+      out: result
+
+    - name: "Sync application"
+      task: argocd
+      in:
+        validateCerts: false
+        action: sync
+        app: test-app
+        revision: "HEAD"
+        watchHealth: true
+        baseUrl: "${argoBaseUrl}"
+        auth:
+          ldap:
+            username: "${argoUsername}"
+            password: "${argoPassword}"
+        syncTimeout: "PT5S"
+        resources: []
+      out: syncResult
+      retry:
+        times: 1
+        in:
+          syncTimeout: "PT5M"
+
+
+    - name: "Get application status"
+      task: argocd
+      in:
+        validateCerts: false
+        action: get
+        baseUrl: "${argoBaseUrl}"
+        app: "test-app"
+        project: default
+        auth:
+          ldap:
+            username: "${argoUsername}"
+            password: "${argoPassword}"
+      out: result
+    - log: "${resource.prettyPrintJson(result)}"
+    - log: "got app status: ${result.app.status.health.status}"
+
+    - name: "Delete application"
+      task: argocd
+      in:
+        validateCerts: false
+        action: delete
+        cascade: true
+        baseUrl: "${argoBaseUrl}"
+        app: "test-app"
+        project: default
+        auth:
+          ldap:
+            username: "${argoUsername}"
+            password: "${argoPassword}"
+      out: result
+
+    - log: "Deleted app: ${result.ok}"

--- a/tasks/argocd/src/test/resources/com/walmartlabs/concord/plugins/argocd/it/runtimeV2/concord.yml
+++ b/tasks/argocd/src/test/resources/com/walmartlabs/concord/plugins/argocd/it/runtimeV2/concord.yml
@@ -1,0 +1,20 @@
+configuration:
+  runtime: "concord-v2"
+  dependencies:
+    - "mvn://com.walmartlabs.concord.plugins:argocd-task:%%version%%"
+
+flows:
+  default:
+    - log: "Hello world"
+    - task: argocd
+      in:
+        action: get
+        baseUrl: "${argoBaseUrl}"
+        app: "test"
+        auth:
+          ldap:
+            username: user
+            password: password
+      out: result
+    - log: "${resource.prettyPrintJson(result)}"
+    - log: "got app status: ${result.app.status.health.status}"

--- a/tasks/argocd/src/test/resources/logback-test.xml
+++ b/tasks/argocd/src/test/resources/logback-test.xml
@@ -4,6 +4,11 @@
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
         </encoder>
     </appender>
+
+    <logger name="org.eclipse.jetty" level="WARN"/>
+    <logger name="org.apache" level="ERROR"/>
+    <logger name="com.walmartlabs.concord" level="INFO"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
## Use Java's native `HttpClient` instead of Apache's.

Streamline dependencies. Less stuff to manage over time.

## Apply `syncTimeout` to entire `CallRetry` operation.

Previously, the timeout was implicitly applied through the http call made within. ArgoCD's sync call is essentially a single long-running `GET` call. Since `CallRetry` is currently only used for that purpose, the reliance on a socket timeout worked "good enough".

This PR's change to `CallRetry` forces a timeout against the call, so if for some odd reason the http's socket timeout doesn't occur, it will still effectively timeout as expected. This further makes the class more reusable for <something else> in the future.

## Apply "fallback" calls after timeout of "main" call in `CallRetry`

Previously, if the main call timed out, then that immediately was the end of things. Now, the fallback call(s) are made in the case of a main call timeout.

## Local integration tests

Added script and Ansible playbook to bootstrap a local ArgoCD instance for integration testing. See details in [README.md](https://github.com/walmartlabs/concord-plugins/compare/argo-native-client?expand=1#diff-923814cb37df2e428bd67525512bf23882b1d15d12aefde45b49bd31a2828344)