### PR TITLE
project: update target concord version to 2.25.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <scm.connection>scm:git:https://github.com/walmartlabs/concord-plugins.git</scm.connection>
 
-        <concord.version>2.19.0</concord.version>
+        <concord.version>2.25.0</concord.version>
         <gson.version>2.10</gson.version>
         <okhttp3.version>3.14.9</okhttp3.version>
         <wiremock.version>3.5.2</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <concord.version>2.25.0</concord.version>
         <gson.version>2.10</gson.version>
         <okhttp3.version>3.14.9</okhttp3.version>
-        <wiremock.version>3.5.2</wiremock.version>
+        <wiremock.version>3.13.0</wiremock.version>
     </properties>
 
     <dependencyManagement>

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoIT.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoIT.java
@@ -93,7 +93,6 @@ public class ArgoIT {
 
         var projectsApi = new ProjectsApi(concord.apiClient());
         var project = projectsApi.getProject(orgName, projectName);
-        project.setAcceptsRawPayload(true);
         project.rawPayloadMode(ProjectEntry.RawPayloadModeEnum.EVERYONE);
         projectsApi.createOrUpdateProject(orgName, project);
 

--- a/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoK3sIT.java
+++ b/tasks/argocd/src/test/java/com/walmartlabs/concord/plugins/argocd/it/ArgoK3sIT.java
@@ -118,7 +118,6 @@ class ArgoK3sIT {
 
         var projectsApi = new ProjectsApi(concord.apiClient());
         var project = projectsApi.getProject(orgName, projectName);
-        project.setAcceptsRawPayload(true);
         project.rawPayloadMode(ProjectEntry.RawPayloadModeEnum.EVERYONE);
         projectsApi.createOrUpdateProject(orgName, project);
 

--- a/tasks/git/src/test/resources/wiremock/commit/mappings/create_status.json
+++ b/tasks/git/src/test/resources/wiremock/commit/mappings/create_status.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "8048b3f1-4948-47fc-9067-63f49fb03cf6",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/commit/mappings/get.json
+++ b/tasks/git/src/test/resources/wiremock/commit/mappings/get.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "c1e3eaa3-3256-457c-886f-8eb3629d6bf5",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/commit/mappings/get_repo.json
+++ b/tasks/git/src/test/resources/wiremock/commit/mappings/get_repo.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "99d34aa8-e91f-4a9b-a665-9702025b5921",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/commit/mappings/list_statuses.json
+++ b/tasks/git/src/test/resources/wiremock/commit/mappings/list_statuses.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "493690f0-2d40-4510-bd93-3c73866467fb",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/issue/mappings/create.json
+++ b/tasks/git/src/test/resources/wiremock/issue/mappings/create.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "47bdd4ae-ec53-4080-9847-a754cee41fa1",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/close_pr.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/close_pr.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "6091d063-ff75-4e40-ac26-2df5432e45b9",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/comment_pr.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/comment_pr.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "ded6aa9c-3909-4b59-a731-eb2ff6585c15",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/create_pr.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/create_pr.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "761b5328-4326-4d8e-bf9b-a43310594098",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/get_commit_list.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/get_commit_list.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "892d58b3-ab96-4dac-984a-40d89f0896b4",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/get_files.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/get_files.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "f0a71dfd-b6e5-4e2c-a953-2a99e873c245",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/get_pr.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/get_pr.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "8f442916-c6f8-4e48-9ae9-1d33fa76be9f",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/list_prs.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/list_prs.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "492e82ab-143a-47ee-87ca-3fbd22a86e2f",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/pullRequest/mappings/merge_pr.json
+++ b/tasks/git/src/test/resources/wiremock/pullRequest/mappings/merge_pr.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "122cb11e-7dff-4024-9604-67d857a592d9",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/contents.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/contents.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "668b6a94-e70e-465b-9628-da58d138c3e1",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/create.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/create.json
@@ -49,7 +49,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "05a56379-8afb-400e-8f1c-25aaa49ce480",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/create_hook.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/create_hook.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "a847b3ac-3db8-447e-b3e2-d5df2f92913d",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/create_ref.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/create_ref.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "94110519-24e0-4920-b3bb-cce183fc2ddb",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/create_tag.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/create_tag.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "35caae72-9fa8-4a80-9eba-389ffd7c9d48",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/delete.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/delete.json
@@ -41,7 +41,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "2af5deae-2156-4fa7-8fdc-0bcb343cc010",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/delete_branch.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/delete_branch.json
@@ -41,7 +41,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "41c22ac5-8fb1-4372-8962-9f572121105f",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/delete_tag.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/delete_tag.json
@@ -41,7 +41,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "1a85519b-9e0a-4c2b-9d1e-ceca60938fa7",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/fork.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/fork.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "5409385f-1485-412e-b77f-1feb6fd9eb6e",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/get_error.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/get_error.json
@@ -23,7 +23,7 @@
       "X-RateLimit-Reset": "1570140015"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "97713e4c-d41c-41df-92b5-85263f798b17",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/get_for_create.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/get_for_create.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "5d5c2c55-bf5e-403f-ad55-3d7abe69c912",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/get_for_delete.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/get_for_delete.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "f449bea2-af07-462d-87d3-e4312a06e3d2",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/list_branches.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/list_branches.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "af5ea018-0ce5-4588-9fee-713d762624cf",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/list_tags.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/list_tags.json
@@ -42,7 +42,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "877092e3-79f8-4d76-9468-90955c03cf74",
   "persistent": true,
   "insertionIndex": 4
 }

--- a/tasks/git/src/test/resources/wiremock/repo/mappings/merge.json
+++ b/tasks/git/src/test/resources/wiremock/repo/mappings/merge.json
@@ -41,7 +41,7 @@
       "X-GitHub-Request-Id": "CAEC:67D2:295A08:3244A9:5D9665B0"
     }
   },
-  "uuid": "43cfd527-8dc8-4025-ab6f-41f6c45a86bd",
+  "uuid": "d9d172b3-8ef7-4113-aa55-b858fd2485ae",
   "persistent": true,
   "insertionIndex": 4
 }


### PR DESCRIPTION
https://github.com/walmartlabs/concord/pull/1081 broke `opentelemetry` when the return type changed for [`State.getThreadError()`](https://github.com/walmartlabs/concord/pull/1081/files#diff-2a7544d23ded04ff76742932ff2b84beae7afe85e3f531e922fcddc0797bc97fR112)

```
Exception in thread "main" java.lang.NoSuchMethodError: 'java.lang.Exception com.walmartlabs.concord.svm.State.getThreadError(com.walmartlabs.concord.svm.ThreadId)'
        at com.walmartlabs.concord.plugins.opentelemetry.TelemetryCollector.beforeCommand(TelemetryCollector.java:106)
        at com.walmartlabs.concord.svm.ExecutionListenerHolder.fireBeforeCommand(ExecutionListenerHolder.java:43)
```