### PR TITLE
project: update concord-targetplatform to 2.42.0 and JDK25 compat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
                 <plugin>
                     <groupId>dev.ybrig.concord</groupId>
                     <artifactId>concord-maven-plugin</artifactId>
-                    <version>0.0.30</version>
+                    <version>0.0.38</version>
                     <configuration>
                         <concordVersion>${concord.version}</concordVersion>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
         <scm.connection>scm:git:https://github.com/walmartlabs/concord-plugins.git</scm.connection>
 
-        <concord.version>2.35.0</concord.version>
+        <concord.version>2.42.0</concord.version>
         <gson.version>2.10</gson.version>
         <okhttp3.version>3.14.9</okhttp3.version>
         <wiremock.version>3.13.0</wiremock.version>

--- a/tasks/hashivault/pom.xml
+++ b/tasks/hashivault/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -79,17 +79,16 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>vault</artifactId>
+            <artifactId>testcontainers-vault</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>nginx</artifactId>
+            <artifactId>testcontainers-nginx</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -99,7 +98,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.17.3</version>
+                <version>2.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tasks/hashivault/src/test/java/com/walmartlabs/concord/plugins/hashivault/AbstractVaultTest.java
+++ b/tasks/hashivault/src/test/java/com/walmartlabs/concord/plugins/hashivault/AbstractVaultTest.java
@@ -21,10 +21,10 @@ package com.walmartlabs.concord.plugins.hashivault;
  */
 
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.NginxContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.nginx.NginxContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 import org.testcontainers.vault.VaultContainer;
@@ -46,14 +46,14 @@ public abstract class AbstractVaultTest {
                     .withVaultToken(TEST_VAULT_TOKEN)
                     .withNetwork(network)
                     .withNetworkAliases("vault")
-                    .withSecretInVault("secret/testing", "top_secret=password1","db_password=dbpassword1")
-                    .withSecretInVault("cubbyhole/hello", "cubbyKey=cubbyVal")
+                    .withInitCommand("kv put secret/testing top_secret=password1 db_password=dbpassword1")
+                    .withInitCommand("kv put cubbyhole/hello cubbyKey=cubbyVal")
                     // we could explicitly wait for the http endpoint to be available here,
                     // but the nginx check will implicitly handle that
                     .waitingFor(Wait.forLogMessage(".*Vault server started.*", 1));
     @Container
-    public static NginxContainer<?> nginxContainer =
-            new NginxContainer<>(DockerImageName
+    public static NginxContainer nginxContainer =
+            new NginxContainer(DockerImageName
                     // set env var to point to specific image/custom repo
                     .parse(System.getenv("NGINX_IMAGE_VERSION"))
                     .asCompatibleSubstituteFor("nginx"))
@@ -68,6 +68,7 @@ public abstract class AbstractVaultTest {
                             .forStatusCode(200)
                             .allowInsecure());
 
+    @SuppressWarnings("HttpUrlsUsage")
     protected static String getVaultBaseUrl() {
         return String.format("http://%s:%s",
                 vaultContainer.getHost(),

--- a/tasks/s3/pom.xml
+++ b/tasks/s3/pom.xml
@@ -87,7 +87,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>2.0.3</version> <!-- can be removed after upgrading concord platform to 2.37.0+ -->
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update platform version and unpin dependencies for compat with JDK25 (remain at lang level 17) and Concord `2.42.0+`. Remains backwards compatible with at least `2.35.0`.