### PR TITLE
terraform-task: init action

### DIFF
--- a/tasks/argocd/src/test/resources/example-flow/concord.yml
+++ b/tasks/argocd/src/test/resources/example-flow/concord.yml
@@ -63,7 +63,7 @@ forms:
 configuration:
   runtime: concord-v2
   dependencies:
-    - mvn://com.walmartlabs.concord.plugins:argocd-task:1.54.0-SNAPSHOT
+    -  коmvn://com.walmartlabs.concord.plugins:argocd-task:1.54.0-SNAPSHOT
   arguments:
     defaults:
       baseUrl: "https://argocd.demo.com:30443"  # replace with actual url

--- a/tasks/argocd/src/test/resources/example-flow/concord.yml
+++ b/tasks/argocd/src/test/resources/example-flow/concord.yml
@@ -63,7 +63,7 @@ forms:
 configuration:
   runtime: concord-v2
   dependencies:
-    -  коmvn://com.walmartlabs.concord.plugins:argocd-task:1.54.0-SNAPSHOT
+    - mvn://com.walmartlabs.concord.plugins:argocd-task:1.54.0-SNAPSHOT
   arguments:
     defaults:
       baseUrl: "https://argocd.demo.com:30443"  # replace with actual url

--- a/tasks/terraform/README.md
+++ b/tasks/terraform/README.md
@@ -4,6 +4,12 @@ Based on the internal version by:
 - [Prasanth Pendam](https://github.com/ppendha)
 - [Yury Brigadirenko](https://github.com/brig)
 
+## Actions
+
+The task supports `init`, `plan`, `apply`, `output`, and `destroy`.
+`init` initializes the configured backend and runs `terraform init` without running
+plan/apply/destroy.
+
 ## Testing
 
 ### TerraformTaskIT

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Action.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/Action.java
@@ -21,6 +21,7 @@ package com.walmartlabs.concord.plugins.terraform;
  */
 
 public enum Action {
+    INIT,
     APPLY,
     PLAN,
     OUTPUT,

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommon.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommon.java
@@ -50,6 +50,10 @@ public final class TerraformTaskCommon {
             backend.lock();
 
             switch (action) {
+                case INIT: {
+                    InitAction a = new InitAction(workDir, cfg, env);
+                    return a.exec(terraform, backend);
+                }
                 case PLAN: {
                     PlanAction a = new PlanAction(workDir, cfg, env);
                     return a.exec(terraform, backend);

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/InitAction.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/actions/InitAction.java
@@ -1,0 +1,52 @@
+package com.walmartlabs.concord.plugins.terraform.actions;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.plugins.terraform.Terraform;
+import com.walmartlabs.concord.plugins.terraform.backend.Backend;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+public class InitAction extends Action {
+
+    private final Map<String, String> env;
+
+    public InitAction(Path workDir, Map<String, Object> cfg, Map<String, String> env) {
+        super(workDir, cfg);
+        this.env = env;
+    }
+
+    public TerraformActionResult exec(Terraform terraform, Backend backend) throws Exception {
+        try {
+            init(env, terraform, backend);
+            return TerraformActionResult.ok(null);
+        } catch (Exception e) {
+            if (!isIgnoreErrors()) {
+                throw e;
+            }
+
+            return TerraformActionResult.error(e.getMessage());
+        } finally {
+            cleanup(null, backend);
+        }
+    }
+}

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommonTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/TerraformTaskCommonTest.java
@@ -1,0 +1,80 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc., Concord Authors
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import com.walmartlabs.concord.plugins.terraform.actions.TerraformActionResult;
+import com.walmartlabs.concord.plugins.terraform.backend.Backend;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TerraformTaskCommonTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testInitAction() throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(TaskConstants.ACTION_KEY, Action.INIT.name());
+        cfg.put(TaskConstants.PWD_KEY, tempDir.toString());
+        cfg.put(TaskConstants.DIR_KEY, tempDir.toString());
+        cfg.put(TaskConstants.BACKEND_CONFIG_KEY, Arrays.asList(
+                "path/to/config.hcl",
+                "key=my/state.tfstate"
+        ));
+
+        Terraform terraform = mock(Terraform.class);
+        TerraformArgs args = mock(TerraformArgs.class);
+        when(args.hasChdir()).thenReturn(true);
+        when(args.add(anyString(), anyString())).thenReturn(args);
+        when(terraform.buildArgs(any(), any(Path.class))).thenReturn(args);
+        when(terraform.exec(any(), anyString(), anyBoolean(), anyMap(), any(TerraformArgs.class)))
+                .thenReturn(new Terraform.Result(0, "", ""));
+
+        Backend backend = mock(Backend.class);
+
+        TerraformActionResult result = TerraformTaskCommon.execute(terraform, Action.INIT, backend, tempDir, cfg,
+                Collections.emptyMap());
+
+        assertTrue(result.isOk());
+        verify(backend).lock();
+        verify(backend).init(tempDir);
+        verify(args).add("-backend-config", "path/to/config.hcl");
+        verify(args).add("-backend-config", "key=my/state.tfstate");
+        verify(backend).cleanup(tempDir);
+        verify(backend).unlock();
+    }
+}


### PR DESCRIPTION
Adds support for the `init` action in the Terraform task.

The new action runs `terraform init` without performing plan, apply, or destroy.
It prepares the working directory by configuring the backend and downloading
required provider plugins and modules. This allows init to run as a separate,
non-destructive preparation step before `plan` or `apply`.