### PR TITLE
msteams: add updateActivity action to msteamsV2 task

### DIFF
--- a/tasks/msteams/src/main/java/com/walmartlabs/concord/plugins/msteams/TeamsClientV2.java
+++ b/tasks/msteams/src/main/java/com/walmartlabs/concord/plugins/msteams/TeamsClientV2.java
@@ -79,6 +79,11 @@ public class TeamsClientV2 implements AutoCloseable {
         return exec(activity, rootApi);
     }
 
+    public Result updateActivity(Map<String, Object> activity, String rootApi, String conversationId, String activityId) throws IOException {
+        rootApi = rootApi + "/" + conversationId + "/activities/" + activityId;
+        return exec(activity, rootApi, "PUT");
+    }
+
     private HttpRequest.Builder buildRequest() {
         var builder = HttpRequest.newBuilder();
 
@@ -88,9 +93,13 @@ public class TeamsClientV2 implements AutoCloseable {
     }
 
     Result exec(Map<String, Object> params, String rootApi) throws IOException {
+        return exec(params, rootApi, "POST");
+    }
+
+    Result exec(Map<String, Object> params, String rootApi, String method) throws IOException {
         var request = buildRequest()
                 .uri(URI.create(rootApi))
-                .POST(HttpRequest.BodyPublishers.ofString(Utils.mapper().writeValueAsString(params)))
+                .method(method, HttpRequest.BodyPublishers.ofString(Utils.mapper().writeValueAsString(params)))
                 .header("Content-Type", "application/json")
                 .build();
 
@@ -109,7 +118,10 @@ public class TeamsClientV2 implements AutoCloseable {
                         return new Result(false, "empty response", null, null, null);
                     }
 
-                    if (response.statusCode() != Constants.TEAMS_SUCCESS_STATUS_CODE_V2) {
+                    // activity updates (PUT) return 200, other calls return 201
+                    var success = response.statusCode() == Constants.TEAMS_SUCCESS_STATUS_CODE_V2
+                            || ("PUT".equals(method) && response.statusCode() == Constants.TEAMS_SUCCESS_STATUS_CODE);
+                    if (!success) {
                         log.error("exec [params: '{}'] -> failed response", params);
                         return new Result(false, body, null, null, null);
                     }

--- a/tasks/msteams/src/main/java/com/walmartlabs/concord/plugins/msteams/TeamsV2TaskCommon.java
+++ b/tasks/msteams/src/main/java/com/walmartlabs/concord/plugins/msteams/TeamsV2TaskCommon.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static com.walmartlabs.concord.plugins.msteams.TeamsV2TaskParams.CreateConversationParams;
 import static com.walmartlabs.concord.plugins.msteams.TeamsV2TaskParams.ReplayToConversationParams;
+import static com.walmartlabs.concord.plugins.msteams.TeamsV2TaskParams.UpdateActivityParams;
 
 public class TeamsV2TaskCommon {
 
@@ -50,6 +51,9 @@ public class TeamsV2TaskCommon {
             }
             case REPLYTOCONVERSATION: {
                 return replyToConversation((ReplayToConversationParams)in);
+            }
+            case UPDATEACTIVITY: {
+                return updateActivity((UpdateActivityParams)in);
             }
             default:
                 throw new IllegalArgumentException("Unsupported action type: " + in.action());
@@ -97,6 +101,30 @@ public class TeamsV2TaskCommon {
                 return Result.error(e.getMessage());
             } else {
                 throw new RuntimeException("'msteams' task error: " + e.getMessage());
+            }
+        }
+    }
+
+    Result updateActivity(UpdateActivityParams in) {
+        String conversationId = in.conversationId();
+        String activityId = in.activityId();
+
+        try (TeamsClientV2 client = getClient(in)) {
+            Result r = client.updateActivity(in.activity(), in.rootApi(), conversationId, activityId);
+
+            if (!r.isOk()) {
+                log.warn("Error updating activity: {}", r.getError());
+            } else {
+                log.info("Activity updated.");
+            }
+            return r;
+        } catch (Exception e) {
+            if (in.ignoreErrors()) {
+                log.warn("Finished with generic error (networking or internal 'msteams' error). " +
+                        "For details check for the 'ERROR': {}", e.getMessage());
+                return Result.error(e.getMessage());
+            } else {
+                throw new RuntimeException("'msteams' task error while updating activity: " + e.getMessage());
             }
         }
     }

--- a/tasks/msteams/src/main/java/com/walmartlabs/concord/plugins/msteams/TeamsV2TaskParams.java
+++ b/tasks/msteams/src/main/java/com/walmartlabs/concord/plugins/msteams/TeamsV2TaskParams.java
@@ -38,6 +38,9 @@ public class TeamsV2TaskParams implements TeamsV2Configuration {
             case REPLYTOCONVERSATION: {
                 return new ReplayToConversationParams(variables);
             }
+            case UPDATEACTIVITY: {
+                return new UpdateActivityParams(variables);
+            }
             default:
                 throw new IllegalArgumentException("Unsupported action type: " + action);
         }
@@ -167,8 +170,22 @@ public class TeamsV2TaskParams implements TeamsV2Configuration {
         }
     }
 
+    public static class UpdateActivityParams extends ReplayToConversationParams {
+
+        private static final String VAR_ACTIVITY_ID = "activityId";
+
+        public UpdateActivityParams(Variables variables) {
+            super(variables);
+        }
+
+        public String activityId() {
+            return variables.assertString(VAR_ACTIVITY_ID);
+        }
+    }
+
     public enum Action {
         CREATECONVERSATION,
-        REPLYTOCONVERSATION
+        REPLYTOCONVERSATION,
+        UPDATEACTIVITY
     }
 }

--- a/tasks/msteams/src/test/java/com/walmartlabs/concord/plugins/msteams/CommonV2Test.java
+++ b/tasks/msteams/src/test/java/com/walmartlabs/concord/plugins/msteams/CommonV2Test.java
@@ -22,6 +22,7 @@ package com.walmartlabs.concord.plugins.msteams;
 
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.walmartlabs.concord.runtime.v2.sdk.MapBackedVariables;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -136,6 +138,52 @@ class CommonV2Test {
         var messageEvent = rule.getAllServeEvents().get(0);
         assertNotNull(messageEvent);
         assertEquals("/amer/v3/conversations/" + MOCK_CONVERSATION_ID + "/activities", messageEvent.getRequest().getUrl());
+    }
+
+    @Test
+    void testUpdateActivity() throws Exception {
+        stubForAuth();
+        stubForUpdateActivity();
+
+        var input = new HashMap<>(defaultParams());
+        input.put("action", "updateActivity");
+        input.put("conversationId", MOCK_CONVERSATION_ID);
+        input.put("activityId", MOCK_ACTIVITY_ID);
+        input.put("activity", Map.of(
+                "type", "message",
+                "text", "mock updated text"
+        ));
+
+        Result r = common.execute(TeamsV2TaskParams.of(new MapBackedVariables(input), Map.of()));
+
+        assertTrue(r.isOk());
+
+        verify(common, times(1)).getClient(any(TeamsV2TaskParams.class));
+        verify(common, times(1)).updateActivity(any(TeamsV2TaskParams.UpdateActivityParams.class));
+        verify(client, times(1)).exec(any(), any(), any());
+        verify(client, times(0)).sleep(anyLong());
+
+        var authEvent = rule.getAllServeEvents().get(1);
+        assertNotNull(authEvent);
+        assertEquals("/botframework.com/oauth2/v2.0/token", authEvent.getRequest().getUrl());
+
+        var messageEvent = rule.getAllServeEvents().get(0);
+        assertNotNull(messageEvent);
+        assertEquals(RequestMethod.PUT, messageEvent.getRequest().getMethod());
+        assertEquals("/amer/v3/conversations/" + MOCK_CONVERSATION_ID + "/activities/" + MOCK_ACTIVITY_ID,
+                messageEvent.getRequest().getUrl());
+    }
+
+    @Test
+    void testUpdateActivityMissingActivityId() {
+        var input = new HashMap<>(defaultParams());
+        input.put("action", "updateActivity");
+        input.put("conversationId", MOCK_CONVERSATION_ID);
+
+        var params = TeamsV2TaskParams.of(new MapBackedVariables(input), Map.of());
+
+        var expected = assertThrows(IllegalArgumentException.class, () -> common.execute(params));
+        assertTrue(expected.getMessage().contains("activityId"));
     }
 
     @Test
@@ -250,6 +298,20 @@ class CommonV2Test {
                                 "id", MOCK_REPLY_ID
                         )))));
 
+    }
+
+    void stubForUpdateActivity() throws Exception {
+        rule.stubFor(put(urlEqualTo("/amer/v3/conversations/" + MOCK_CONVERSATION_ID + "/activities/" + MOCK_ACTIVITY_ID))
+                .withRequestBody(equalToJson(Utils.mapper().writeValueAsString(Map.of(
+                        "type", "message",
+                        "text", "mock updated text"
+                )), true, false))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json; charset=utf-8")
+                        .withJsonBody(Utils.mapper().valueToTree(Map.of(
+                                "id", MOCK_ACTIVITY_ID
+                        )))));
     }
 
     void stubForTooManyRequests() {


### PR DESCRIPTION
## Problem

The `msteamsV2` task supports only `createConversation` and `replyToConversation` — there is no way to update a posted activity in place. The Bot Framework supports this via `PUT {rootApi}/{conversationId}/activities/{activityId}`, the same base URL `replyToConversation` already builds plus one path segment and a different HTTP verb.

## Use case

Live-updating status cards: a flow posts an Adaptive Card (e.g. PR checks/approvals status) and later rebuilds and replaces it in place, instead of accumulating thread replies for every state change.

## What changed

- **`TeamsV2TaskParams.java`** — new `UPDATEACTIVITY` action, new `UpdateActivityParams` (extends `ReplayToConversationParams`, adds required `activityId`), and the corresponding `of()` dispatch case.
- **`TeamsClientV2.java`** — `exec(Map, String)` refactored into `exec(Map, String, String method)` using `HttpRequest.Builder.method(...)`; the old two-arg signature delegates to `"POST"`, so existing behavior is unchanged. New `updateActivity(activity, rootApi, conversationId, activityId)` builds `{rootApi}/{conversationId}/activities/{activityId}` and issues a `PUT`.
- **`TeamsV2TaskCommon.java`** — `UPDATEACTIVITY` switch case and an `updateActivity(...)` handler with the same error/`ignoreErrors` semantics as `replyToConversation`.
- **`CommonV2Test.java`** — new tests assert the request verb is `PUT`, the URL is `{rootApi}/{conversationId}/activities/{activityId}`, a success response maps to `result.ok == true`, and a missing `activityId` throws. All existing tests pass unmodified.

Note on status codes: `exec` previously accepted only `201` as success. The Bot Framework's update-activity endpoint returns `200 OK`, so the new `PUT` path also accepts `200` (`Constants.TEAMS_SUCCESS_STATUS_CODE`). POST paths keep the exact 201-only check.

## Example flow

```yaml
flows:
  updateStatusCard:
    - task: msteamsV2
      in:
        action: updateActivity
        conversationId: ${createResult.conversationId}
        activityId: ${createResult.activityId}
        activity:
          type: message
          attachments:
            - contentType: application/vnd.microsoft.card.adaptive
              content:
                type: AdaptiveCard
                version: "1.4"
                body:
                  - type: TextBlock
                    text: "Build #42: PASSED"
      out: updateResult
```

## Testing

- `./mvnw -B -pl tasks/msteams -am clean verify` — full module build and test suite green (13 tests, existing tests unmodified).
- This change is already merged and in use in our fork ([citizen-123#1](https://github.com/citizen-123/concord-plugins/pull/1)).
- `MSTeamsV2IT` was **not** run: it is `@Disabled("requires sensitive vars file")` and needs a live tenant/bot config in `it_vars/default.json`. Happy to run it against an integration test channel if maintainers can share guidance.

## Docs

The plugin docs (`walmartlabs/concord-website`, `docs/plugins-v2/msteams.md`) are not updated by this PR; a follow-up documenting `updateActivity` with the YAML example above is ready to go once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
