### PR TITLE
terraform: add git module support for http authentication

### DIFF
--- a/tasks/terraform/README.md
+++ b/tasks/terraform/README.md
@@ -10,6 +10,32 @@ The task supports `init`, `plan`, `apply`, `output`, and `destroy`.
 `init` initializes the configured backend and runs `terraform init` without running
 plan/apply/destroy.
 
+## Git module authentication
+
+`gitAuth` can be used for both SSH key auth and HTTP(S) username/password auth when Terraform
+downloads git modules.
+
+```yaml
+- task: terraform
+  in:
+    action: plan
+    gitAuth:
+      # existing SSH support
+      privateKeys:
+      - "/path/to/id_rsa"
+      secrets:
+      - org: "Default"
+        secretName: "my-ssh-key"
+        password: "optional"
+
+      # or HTTP(S) auth support
+      http:
+        password: "${myGitPasswordOrToken}"
+        username: "x-access-token" # optional, defaults to x-access-token
+```
+
+`gitSsh` is still accepted for backward compatibility, but it is deprecated and will log a warning.
+
 ## Testing
 
 ### TerraformTaskIT

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/GitSshWrapper.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/GitSshWrapper.java
@@ -34,7 +34,8 @@ import static java.lang.System.lineSeparator;
 
 /**
  * Generates a <a href="https://git-scm.com/docs/git#Documentation/git.txt-codeGITSSHCOMMANDcode">GIT_SSH_COMMAND</a>
- * script using the specified private key files and/or Concord secrets.
+ * script using the specified private key files and/or Concord secrets and
+ * optionally configures Git HTTP(S) credentials for password-based module cloning.
  */
 public class GitSshWrapper {
 
@@ -42,10 +43,13 @@ public class GitSshWrapper {
 
     public static final String PRIVATE_KEYS_KEY = "privateKeys";
     public static final String SECRETS_KEY = "secrets";
+    public static final String HTTP_KEY = "http";
 
     private static final String ORG_KEY = "org";
     private static final String SECRET_NAME_KEY = "secretName";
     private static final String PASSWORD_KEY = "password";
+    private static final String USERNAME_KEY = "username";
+    private static final String DEFAULT_HTTP_USERNAME = "x-access-token";
 
     private static final String SCRIPT_PERMISSIONS = "r-xr-xr--";
 
@@ -55,24 +59,41 @@ public class GitSshWrapper {
                                            Map<String, Object> cfg,
                                            boolean debug) throws Exception {
 
-        Object v = cfg.getOrDefault(TaskConstants.GIT_SSH_KEY, Collections.emptyMap());
+        Object gitAuthCfg = cfg.get(TaskConstants.GIT_AUTH_KEY);
+        Object gitSshCfg = cfg.get(TaskConstants.GIT_SSH_KEY);
+
+        if (gitSshCfg != null) {
+            log.warn("'{}' is deprecated and will be removed in a future release. Use '{}' instead.",
+                    TaskConstants.GIT_SSH_KEY, TaskConstants.GIT_AUTH_KEY);
+        }
+
+        String rootKey = TaskConstants.GIT_AUTH_KEY;
+        Object v = Collections.emptyMap();
+        if (gitAuthCfg != null) {
+            v = gitAuthCfg;
+        } else if (gitSshCfg != null) {
+            rootKey = TaskConstants.GIT_SSH_KEY;
+            v = gitSshCfg;
+        }
+
         if (!(v instanceof Map)) {
-            throw new IllegalArgumentException("'" + TaskConstants.GIT_SSH_KEY + "' must be a object, got: " + v);
+            throw new IllegalArgumentException("'" + rootKey + "' must be a object, got: " + v);
         }
 
         Map<String, Object> m = (Map<String, Object>) v;
 
-        List<Path> externalKeys = getExternalPrivateKeys(workDir, m, debug);
-        List<Path> exportedKeys = exportSecrets(secretProvider, m, debug);
+        List<Path> externalKeys = getExternalPrivateKeys(workDir, m, rootKey, debug);
+        List<Path> exportedKeys = exportSecrets(secretProvider, m, rootKey, debug);
+        HttpAuth httpAuth = getHttpAuth(m, rootKey, debug);
 
-        return new GitSshWrapper(externalKeys, exportedKeys, debug);
+        return new GitSshWrapper(externalKeys, exportedKeys, httpAuth, debug);
     }
 
     @SuppressWarnings("unchecked")
-    private static List<Path> getExternalPrivateKeys(Path workDir, Map<String, Object> m, boolean debug) {
+    private static List<Path> getExternalPrivateKeys(Path workDir, Map<String, Object> m, String rootKey, boolean debug) {
         Object v = m.getOrDefault(PRIVATE_KEYS_KEY, Collections.emptyList());
         if (!(v instanceof List)) {
-            throw new IllegalArgumentException("'" + TaskConstants.GIT_SSH_KEY + "." + PRIVATE_KEYS_KEY + "' must be a list of paths, got: " + v);
+            throw new IllegalArgumentException("'" + rootKey + "." + PRIVATE_KEYS_KEY + "' must be a list of paths, got: " + v);
         }
 
         List<Path> result = new ArrayList<>();
@@ -84,7 +105,7 @@ public class GitSshWrapper {
             } else if (o instanceof String) {
                 p = workDir.resolve((String) o);
             } else {
-                throw new IllegalArgumentException("'" + TaskConstants.GIT_SSH_KEY + "." + PRIVATE_KEYS_KEY + "' elements must be private key paths, got: " + o);
+                throw new IllegalArgumentException("'" + rootKey + "." + PRIVATE_KEYS_KEY + "' elements must be private key paths, got: " + o);
             }
 
             if (!p.isAbsolute()) {
@@ -107,20 +128,21 @@ public class GitSshWrapper {
     @SuppressWarnings("unchecked")
     private static List<Path> exportSecrets(SecretProvider secretProvider,
                                             Map<String, Object> m,
+                                            String rootKey,
                                             boolean debug) throws Exception {
 
         Object v = m.getOrDefault(SECRETS_KEY, Collections.emptyList());
         if (!(v instanceof List)) {
-            throw new IllegalArgumentException("'" + TaskConstants.GIT_SSH_KEY + "." + SECRETS_KEY + "' must be a list of secrets to export, got: " + v);
+            throw new IllegalArgumentException("'" + rootKey + "." + SECRETS_KEY + "' must be a list of secrets to export, got: " + v);
         }
 
         List<Path> result = new ArrayList<>();
         for (Object o : (List<Object>) v) {
             if (!(o instanceof Map)) {
-                throw new IllegalArgumentException("'" + TaskConstants.GIT_SSH_KEY + "." + SECRETS_KEY + "' values must be Concord secrets references, got: " + o);
+                throw new IllegalArgumentException("'" + rootKey + "." + SECRETS_KEY + "' values must be Concord secrets references, got: " + o);
             }
 
-            Path p = exportSecret(secretProvider, (Map<String, Object>) o, debug);
+            Path p = exportSecret(secretProvider, (Map<String, Object>) o, rootKey, debug);
             result.add(p);
         }
         return result;
@@ -128,6 +150,7 @@ public class GitSshWrapper {
 
     private static Path exportSecret(SecretProvider secretProvider,
                                      Map<String, Object> m,
+                                     String rootKey,
                                      boolean debug) throws Exception {
 
         m = new HashMap<>(m);
@@ -141,7 +164,7 @@ public class GitSshWrapper {
         String password = removeString(m, PASSWORD_KEY);
 
         if (!m.isEmpty()) {
-            throw new IllegalArgumentException("Unrecognized options of '" + TaskConstants.GIT_SSH_KEY + "." + SECRETS_KEY + "': " + m.keySet());
+            throw new IllegalArgumentException("Unrecognized options of '" + rootKey + "." + SECRETS_KEY + "': " + m.keySet());
         }
 
         Path p = secretProvider.getPrivateKey(orgName, secretName, password);
@@ -152,16 +175,58 @@ public class GitSshWrapper {
         return p;
     }
 
+    @SuppressWarnings("unchecked")
+    private static HttpAuth getHttpAuth(Map<String, Object> m, String rootKey, boolean debug) {
+        Object v = m.get(HTTP_KEY);
+        if (v == null) {
+            return null;
+        }
+
+        if (!(v instanceof Map)) {
+            throw new IllegalArgumentException("'" + rootKey + "." + HTTP_KEY + "' must be an object, got: " + v);
+        }
+
+        HttpAuth a = parseHttpAuth((Map<String, Object>) v, rootKey);
+        if (debug) {
+            log.info("getHttpAuth -> using HTTP git auth with username {}", a.username);
+        }
+        return a;
+    }
+
+    private static HttpAuth parseHttpAuth(Map<String, Object> m, String rootKey) {
+        m = new HashMap<>(m);
+
+        String password = removeString(m, PASSWORD_KEY);
+        if (password == null) {
+            throw new IllegalArgumentException("'" + PASSWORD_KEY + "' is required, got: " + m);
+        }
+
+        String username = removeString(m, USERNAME_KEY);
+        if (username == null) {
+            username = DEFAULT_HTTP_USERNAME;
+        }
+
+        if (!m.isEmpty()) {
+            throw new IllegalArgumentException("Unrecognized options of '" + rootKey + "." + HTTP_KEY + "': " + m.keySet());
+        }
+
+        return new HttpAuth(username, password);
+    }
+
     private final List<Path> externalPrivateKeys;
     private final List<Path> exportedPrivateKeys;
+    private final HttpAuth httpAuth;
     private final boolean debug;
 
     // path to the generated SSH wrapper script, removed in cleanup()
     private Path wrapperPath;
+    // path to generated askpass file, removed in cleanup()
+    private Path askPassPath;
 
-    private GitSshWrapper(List<Path> externalPrivateKeys, List<Path> exportedPrivateKeys, boolean debug) {
+    private GitSshWrapper(List<Path> externalPrivateKeys, List<Path> exportedPrivateKeys, HttpAuth httpAuth, boolean debug) {
         this.externalPrivateKeys = externalPrivateKeys;
         this.exportedPrivateKeys = exportedPrivateKeys;
+        this.httpAuth = httpAuth;
         this.debug = debug;
     }
 
@@ -169,12 +234,23 @@ public class GitSshWrapper {
         this.wrapperPath = generateScript(workDir);
         String s = wrapperPath.toAbsolutePath().toString();
         m.put("GIT_SSH_COMMAND", s);
+        m.put("GIT_TERMINAL_PROMPT", "0");
+
+        if (httpAuth != null) {
+            this.askPassPath = generateAskPassScript(workDir, httpAuth);
+            m.put("GIT_ASKPASS", askPassPath.toAbsolutePath().toString());
+        }
+
         return m;
     }
 
     public void cleanup() throws IOException {
         if (wrapperPath != null) {
             Files.deleteIfExists(wrapperPath);
+        }
+
+        if (askPassPath != null) {
+            Files.deleteIfExists(askPassPath);
         }
 
         for (Path p : exportedPrivateKeys) {
@@ -198,7 +274,7 @@ public class GitSshWrapper {
 
         sb.append(" $@");
 
-        String cmd = sb.toString();
+        String cmd = sb.append("\n").toString();
 
         Path dst = Files.createTempFile(dir, "gitSsh", ".sh");
         Files.write(dst, cmd.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
@@ -209,6 +285,24 @@ public class GitSshWrapper {
 
     private static void addIdentityFile(StringBuilder sb, Path p) {
         sb.append(" -o IdentityFile=").append(p.toString());
+    }
+
+    private Path generateAskPassScript(Path dir, HttpAuth auth) throws IOException {
+        String cmd = "#!/bin/sh" + lineSeparator() +
+                "case \"$1\" in" + lineSeparator() +
+                "  *sername*) printf '%s\\n' " + shellQuote(auth.username) + " ;;" + lineSeparator() +
+                "  *assword*) printf '%s\\n' " + shellQuote(auth.password) + " ;;" + lineSeparator() +
+                "  *) printf '\\n' ;;" + lineSeparator() +
+                "esac\n";
+
+        Path dst = Files.createTempFile(dir, "gitAskPass", ".sh");
+        Files.write(dst, cmd.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
+        Files.setPosixFilePermissions(dst, PosixFilePermissions.fromString(SCRIPT_PERMISSIONS));
+        return dst;
+    }
+
+    private static String shellQuote(String value) {
+        return "'" + value.replace("'", "'\"'\"'") + "'";
     }
 
     private static String removeString(Map<String, Object> m, String k) {
@@ -228,4 +322,8 @@ public class GitSshWrapper {
 
         Path getPrivateKey(String orgName, String secretName, String password) throws Exception;
     }
+
+    private record HttpAuth(String username, String password) {
+    }
+
 }

--- a/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TaskConstants.java
+++ b/tasks/terraform/src/main/java/com/walmartlabs/concord/plugins/terraform/TaskConstants.java
@@ -33,6 +33,7 @@ public final class TaskConstants {
     public static final String DOCKER_IMAGE_KEY = "dockerImage";
     public static final String EXTRA_ENV_KEY = "extraEnv";
     public static final String EXTRA_VARS_KEY = "extraVars";
+    public static final String GIT_AUTH_KEY = "gitAuth";
     public static final String GIT_SSH_KEY = "gitSsh";
     public static final String HOSTNAME_KEY = "hostname";
     public static final String IGNORE_ERRORS_KEY = "ignoreErrors";
@@ -54,9 +55,9 @@ public final class TaskConstants {
     public static final String TF_CLI_CONFIG_FILE_KEY = "TF_CLI_CONFIG_FILE";
 
     static final String[] ALL_IN_PARAMS = {ACTION_KEY, BACKEND_KEY, BACKEND_CONFIG_KEY, DEBUG_KEY, DEFAULT_ENV_KEY, DESTROY_KEY,
-            DIR_KEY, DOCKER_IMAGE_KEY, EXTRA_ENV_KEY, EXTRA_VARS_KEY, VARS_FILES, GIT_SSH_KEY, IGNORE_ERRORS_KEY, IGNORE_LOCAL_BINARY_KEY,
-            MODULE_KEY, PLAN_KEY, PWD_KEY, RESULT_KEY, SAVE_OUTPUT_KEY, STATE_ID_KEY, VERBOSE_KEY, TARGET_KEY,
-            TOOL_VERSION_KEY, TOOL_URL_KEY, TOOL_ARCH_KEY};
+            DIR_KEY, DOCKER_IMAGE_KEY, EXTRA_ENV_KEY, EXTRA_VARS_KEY, VARS_FILES, GIT_AUTH_KEY, GIT_SSH_KEY, IGNORE_ERRORS_KEY,
+            IGNORE_LOCAL_BINARY_KEY, MODULE_KEY, PLAN_KEY, PWD_KEY, RESULT_KEY, SAVE_OUTPUT_KEY, STATE_ID_KEY, VERBOSE_KEY,
+            TARGET_KEY, TOOL_VERSION_KEY, TOOL_URL_KEY, TOOL_ARCH_KEY};
 
     private TaskConstants() {
     }

--- a/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/GitSshWrapperTest.java
+++ b/tasks/terraform/src/test/java/com/walmartlabs/concord/plugins/terraform/GitSshWrapperTest.java
@@ -1,0 +1,147 @@
+package com.walmartlabs.concord.plugins.terraform;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2017 - 2026 Walmart Inc.
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GitSshWrapperTest {
+
+    @TempDir
+    Path workDir;
+
+    @Test
+    void shouldConfigureHttpGitCredentials() throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(TaskConstants.GIT_AUTH_KEY, Collections.singletonMap(
+                GitSshWrapper.HTTP_KEY, Map.of(
+                        "password", "ab+c:d@z")));
+
+        GitSshWrapper w = GitSshWrapper.createFrom((orgName, secretName, password) -> {
+            throw new IllegalStateException("should not be called");
+        }, workDir, cfg, false);
+
+        Map<String, String> env = w.updateEnv(workDir, new HashMap<>());
+
+        assertTrue(env.containsKey("GIT_ASKPASS"));
+        assertEquals("0", env.get("GIT_TERMINAL_PROMPT"));
+        assertTrue(env.containsKey("GIT_SSH_COMMAND"));
+        assertFalse(env.containsKey("GIT_CONFIG_COUNT"));
+
+        Path askPassPath = Path.of(env.get("GIT_ASKPASS"));
+        assertTrue(Files.exists(askPassPath));
+
+        String askPassScript = Files.readString(askPassPath);
+        assertTrue(askPassScript.contains("x-access-token"));
+        assertTrue(askPassScript.contains("ab+c:d@z"));
+
+        w.cleanup();
+        assertFalse(Files.exists(askPassPath));
+    }
+
+    @Test
+    void shouldRejectHttpAuthWithUrl() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(TaskConstants.GIT_AUTH_KEY, Collections.singletonMap(
+                GitSshWrapper.HTTP_KEY, Map.of(
+                        "url", "ssh://github.com/example/repo.git",
+                        "password", "secret")));
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> GitSshWrapper.createFrom((orgName, secretName, password) -> null, workDir, cfg, false));
+        assertTrue(e.getMessage().contains("Unrecognized options"));
+    }
+
+    @Test
+    void shouldPreferGitAuthOverDeprecatedGitSsh() throws Exception {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(TaskConstants.GIT_AUTH_KEY, Collections.singletonMap(
+                GitSshWrapper.HTTP_KEY, Map.of(
+                        "password", "from-git-auth")));
+        cfg.put(TaskConstants.GIT_SSH_KEY, Collections.singletonMap(
+                GitSshWrapper.HTTP_KEY, Map.of(
+                        "password", "from-git-ssh")));
+
+        GitSshWrapper w = GitSshWrapper.createFrom((orgName, secretName, password) -> null, workDir, cfg, false);
+        Map<String, String> env = w.updateEnv(workDir, new HashMap<>());
+
+        Path askPassPath = Path.of(env.get("GIT_ASKPASS"));
+        String askPassScript = Files.readString(askPassPath);
+        assertTrue(askPassScript.contains("from-git-auth"));
+        assertFalse(askPassScript.contains("from-git-ssh"));
+
+        w.cleanup();
+    }
+
+    @Test
+    void shouldConfigureSshPrivateKeyFromGitAuth() throws Exception {
+        Path privateKey = Files.createTempFile(workDir, "test", ".key");
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(TaskConstants.GIT_AUTH_KEY, Collections.singletonMap(
+                GitSshWrapper.PRIVATE_KEYS_KEY, Collections.singletonList(privateKey.toString())));
+
+        GitSshWrapper w = GitSshWrapper.createFrom((orgName, secretName, password) -> null, workDir, cfg, false);
+        Map<String, String> env = w.updateEnv(workDir, new HashMap<>());
+
+        assertTrue(env.containsKey("GIT_SSH_COMMAND"));
+        assertEquals("0", env.get("GIT_TERMINAL_PROMPT"));
+        assertFalse(env.containsKey("GIT_CONFIG_COUNT"));
+
+        Path wrapperPath = Path.of(env.get("GIT_SSH_COMMAND"));
+        assertTrue(Files.exists(wrapperPath));
+        String wrapperScript = Files.readString(wrapperPath);
+        assertTrue(wrapperScript.contains("IdentityFile=" + privateKey));
+
+        w.cleanup();
+        assertFalse(Files.exists(wrapperPath));
+    }
+
+    @Test
+    void shouldRejectHttpAuthList() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(TaskConstants.GIT_AUTH_KEY, Collections.singletonMap(
+                GitSshWrapper.HTTP_KEY, Collections.singletonList(Map.of("password", "secret"))));
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> GitSshWrapper.createFrom((orgName, secretName, password) -> null, workDir, cfg, false));
+        assertTrue(e.getMessage().contains("must be an object"));
+    }
+
+    @Test
+    void shouldDisableTerminalPromptWithoutGitAuthHttp() throws Exception {
+        GitSshWrapper w = GitSshWrapper.createFrom((orgName, secretName, password) -> null, workDir, Collections.emptyMap(), false);
+        Map<String, String> env = w.updateEnv(workDir, new HashMap<>());
+
+        assertEquals("0", env.get("GIT_TERMINAL_PROMPT"));
+        assertFalse(env.containsKey("GIT_ASKPASS"));
+
+        w.cleanup();
+    }
+
+}


### PR DESCRIPTION
Migrate from `gitSsh` (still works for now) param to `gitAuth` param. Allows specifying ssh private keys in the same way as before, as well as an authentication username and password/token. Can be combined with `github` task's `createAppToken` action for use with a GitHub app.

```yaml
    - task: terraform
      in:
        gitAuth:
          privateKeys:
            - /some/other/pk
          secrets:
            - org: "Default"
              secretName: pk_from_secret
          http:
            password: "${myPasswordVar}"
            username: "my-user" # optional, defaults to 'x-access-token'
          
          # or direct secret export
          http: "${crypto.exportCredentials('MyOrg', 'MyCreds', null)}"
```